### PR TITLE
add theme tailored for multimedia content

### DIFF
--- a/docs/01-introduction.Rmd
+++ b/docs/01-introduction.Rmd
@@ -264,6 +264,8 @@ After you have found a satisfactory theme, you need to figure out its Github use
 
 - Sophisticated themes: [hugo-academic](https://github.com/gcushen/hugo-academic) (strongly recommended for users in academia), [hugo-future-imperfect](https://github.com/jpescador/hugo-future-imperfect), and [hugo-tranquilpeak-theme](https://github.com/kakawait/hugo-tranquilpeak-theme).
 
+- Multimedia content themes: If you are intersted in adding multimedia content to your site (such as audio files of a podcast), the [castanet](https://github.com/mattstratton/castanet) theme provides an excellent framework tailored for this application.  An example of a site using `blogdown` with the castanet theme is the R-Podcast at [www.r-podcast.org](https://www.r-podcast.org).
+
     ```{r eval=FALSE}
     # for example, create a new site with the academic theme
     blogdown::new_site(theme = 'gcushen/hugo-academic')

--- a/docs/01-introduction.Rmd
+++ b/docs/01-introduction.Rmd
@@ -264,7 +264,7 @@ After you have found a satisfactory theme, you need to figure out its Github use
 
 - Sophisticated themes: [hugo-academic](https://github.com/gcushen/hugo-academic) (strongly recommended for users in academia), [hugo-future-imperfect](https://github.com/jpescador/hugo-future-imperfect), and [hugo-tranquilpeak-theme](https://github.com/kakawait/hugo-tranquilpeak-theme).
 
-- Multimedia content themes: If you are intersted in adding multimedia content to your site (such as audio files of a podcast), the [castanet](https://github.com/mattstratton/castanet) theme provides an excellent framework tailored for this application.  An example of a site using `blogdown` with the castanet theme is the R-Podcast at [www.r-podcast.org](https://www.r-podcast.org).
+- Multimedia content themes: If you are interested in adding multimedia content to your site (such as audio files of a podcast), the [castanet](https://github.com/mattstratton/castanet) theme provides an excellent framework tailored for this application.  An example of a site using `blogdown` with the castanet theme is the R-Podcast at [www.r-podcast.org](https://www.r-podcast.org).
 
     ```{r eval=FALSE}
     # for example, create a new site with the academic theme


### PR DESCRIPTION
This PR adds information on a hugo theme called [castanet](https://github.com/mattstratton/castanet) which enables the user to add multimedia content such as audio files from a podcast to a site powered by hugo (see my [podcast site](https://www.r-podcast.org) for an example).  I realize this may be a niche case, but I hope that blogdown combined with this theme will empower more in the R community to start their own podcasts with a site powered by blogdown!