### PR TITLE
Prioritize config.toml over config.yaml

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -161,17 +161,17 @@ load_config = function() {
 
   find_config()
 
-  if (file_exists('config.yaml'))
-    return(read_config('config.yaml', yaml::yaml.load_file))
-
   if (file_exists('config.toml'))
     return(read_config('config.toml', parse_toml))
+
+  if (file_exists('config.yaml'))
+    return(read_config('config.yaml', yaml::yaml.load_file))
 }
 
 find_config = function(error = TRUE) {
   f = existing_files(c('config.toml', 'config.yaml'), first = TRUE)
   if (length(f) == 0 && error) stop(
-    'Cannot find the configuration file config.yaml or config.toml of the website'
+    'Cannot find the configuration file config.toml or config.yaml of the website'
   )
   f
 }


### PR DESCRIPTION
Currently, `load_config()` checks `config.yaml` first. But this is not consistent with the order in which Hugo actually looks for, according to the document:

> First, it looks for a `./config.toml` file. If that’s not present, it will seek a `./config.yaml` file, followed by a `./config.json` file.
(https://gohugo.io/overview/configuration/)

So, I think it would be better to check `config.toml` first.