### PR TITLE
correct shortcode example for twitter

### DIFF
--- a/R/hugo.R
+++ b/R/hugo.R
@@ -269,7 +269,7 @@ hugo_convert = function(to = c('YAML', 'TOML', 'JSON'), unsafe = FALSE, ...) {
 #' @export
 #' @examples library(blogdown)
 #'
-#' shortcode('twitter', 1234567)
+#' shortcode('tweet', 1234567)
 #' shortcode('figure', src='/images/foo.png', alt='A nice figure')
 #' shortcode('highlight', 'bash', .content = 'echo hello world;')
 #'


### PR DESCRIPTION
Using Blogdown and reading the helpfile, I found that current example are misleading.

[Hugo Doc for shortcodes](https://gohugo.io/extras/shortcodes/) explains that the shortcode is
```go
{{< tweet 666616452582129664 >}}
```
In the example of `blogdown::shortcode`, it says `shortcode("twitter", 1234567)` . it should be `shortcode("tweet", 1234567)`. Currently, it is misleading. I follow the example and get an error from hugo. I had to go on internet to find the correct way to do it.

This change impact documentation which I did  not regenerate on purpose to let you do it your way.

If I should have open an issue first, tell me for next time - I do not know how you want to proceed for rstudio packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/blogdown/116)
<!-- Reviewable:end -->
