### PR TITLE
Preserve YAML Sequence when Updating Metadata

### DIFF
--- a/inst/scripts/update_meta.R
+++ b/inst/scripts/update_meta.R
@@ -41,12 +41,16 @@ local({
     )),
     server = function(input, output) {
       shiny::observeEvent(input$done, {
+        seq_keys = Filter(function(key) {
+          isTRUE(attr(yml[[key]], 'yml_type') == 'seq')
+        }, names(yml))
+
         res = list(
           title = input$title, author = input$author, date = format(input$date),
           categories = input$cat, tags = input$tag
         )
         yml = c(res, yml[setdiff(names(yml), names(res))])
-        for (i in c('categories', 'tags')) yml[[i]] = if (length(yml[[i]]) > 0) as.list(yml[[i]])
+        for (i in seq_keys) yml[[i]] = if (length(yml[[i]]) > 0) as.list(yml[[i]])
         rstudioapi::modifyRange(
           slct$range, blogdown:::as.yaml(yml, .trim_ws = FALSE)
         )

--- a/tests/testit/test-utils.R
+++ b/tests/testit/test-utils.R
@@ -26,3 +26,27 @@ assert(
   dash_filename(c('foo Bar', 'foo/bar  !@ hi', '() foo/hello WORLD')) %==%
     c('foo-bar', 'foo-bar-hi', 'foo-hello-world')
 )
+
+test_rmd_file = tempfile()
+test_rmd = '---
+date: \'2017-05-01\'
+string: text
+empty_list: []
+unit_list:
+  - 1
+multi_list:
+  - 1
+  - 2
+---
+'
+
+assert(
+  'modify_yaml perserves original values properly',
+  {
+    write(test_rmd, test_rmd_file)
+    old_content = readUTF8(test_rmd_file)
+
+    modify_yaml(test_rmd_file)
+    readUTF8(test_rmd_file) %==% old_content
+  }
+)


### PR DESCRIPTION
`yaml::yaml.load` always converts YAML sequences into R vectors. On the other hand, Hugo has a strong opinion what should and should not be a sequence (e.g. categories and tags.) Currently, special care is exercised in `update_meta_addin` for these two parameters.

However, the list requirement also applies to all [taxonomies](https://gohugo.io/taxonomies/usage/). This PR attaches `attr(x, "yml_type") <- "seq"` for all sequences, which will be converted back to list later. Otherwise, update metadata add-in always renders front matter, which contains custom taxonomies, invalid for Hugo.

Let me know if you think there is a better approach.

Tested in the unit test for `modify_yaml` and manually for the update metadata add-in.