### PR TITLE
Stop cleaning up *_files/ mistakenly

### DIFF
--- a/R/format.R
+++ b/R/format.R
@@ -44,6 +44,7 @@ html_page = function(
   rmarkdown::output_format(
     knitr = NULL,
     pandoc = NULL,
+    clean_supporting = FALSE,
     post_processor = post_processor,
     base_format = bookdown::html_document2(
       ..., number_sections = number_sections, theme = NULL,


### PR DESCRIPTION
This PR closes #151.

Before #146, `html_page()` was just a wrapper for `bookdown::html_document2()`, which returns a format with `clean_supporting = FALSE`. But now, instead of using the format directly, it overlays the `rmarkdown::output_format()`, whose default argument for `clean_supporting = TRUE`.

If `clean_supporting` is `TRUE`, `rmarkdown::render()` treats `files_dir` as one of `intermediates` and removes it by default.

```r
  # clean the files_dir if we've either been asking to clean supporting files or
  # the knitr cache is active
  if (output_format$clean_supporting && (is.null(cache_dir) || !dir_exists(cache_dir)))
    intermediates <- c(intermediates, files_dir)
```
(https://github.com/rstudio/rmarkdown/blob/8cfe0cbad226edc43e1525eb8592cfa9073d180c/R/render.R#L527)

This PR fixes the issue by explicitly passing `clean_supporting = FALSE` to `rmarkdown::output_format()`.