### PR TITLE
keep yml_type as sequence

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -481,7 +481,7 @@ modify_yaml = function(
     if (!.keep_empty) meta1 = filter_list(meta1)
     if (is.null(meta1[['draft']])) meta1$draft = NULL
     for (i in names(meta1)) {
-      if (identical(attr(meta1[[i]], "yml_type"), "seq")) {
+      if (identical(attr(meta0[[i]], "yml_type"), "seq")) {
         meta1[[i]] = as.list(meta1[[i]])
       }
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -465,8 +465,7 @@ modify_yaml = function(
   x = readUTF8(file)
   res = split_yaml_body(x)
   if (length(yml <- res$yaml) > 2) {
-    meta0 = res$yaml_list
-    meta1 = res$yaml_list
+    meta0 = meta1 = res$yaml_list
     meta2 = list(...)
     for (i in names(meta2)) {
       if (is.function(f <- meta2[[i]])) meta2[i] = list(f(meta1[[i]], meta1))
@@ -481,7 +480,7 @@ modify_yaml = function(
     if (!.keep_empty) meta1 = filter_list(meta1)
     if (is.null(meta1[['draft']])) meta1$draft = NULL
     for (i in names(meta1)) {
-      if (identical(attr(meta0[[i]], "yml_type"), "seq")) {
+      if (identical(attr(meta0[[i]], 'yml_type'), 'seq')) {
         meta1[[i]] = as.list(meta1[[i]])
       }
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -460,8 +460,7 @@ append_yaml = function(x, value = list()) {
 # particular order, and optionally remove empty fields
 modify_yaml = function(
   file, ..., .order = character(), .keep_fields = NULL,
-  .keep_empty = getOption('blogdown.yaml.empty', TRUE),
-  .keep_seq = TRUE
+  .keep_empty = getOption('blogdown.yaml.empty', TRUE)
 ) {
   x = readUTF8(file)
   res = split_yaml_body(x)
@@ -482,16 +481,8 @@ modify_yaml = function(
     if (!.keep_empty) meta1 = filter_list(meta1)
     if (is.null(meta1[['draft']])) meta1$draft = NULL
     for (i in names(meta1)) {
-      if (.keep_seq) {
-        if (!is.null(meta0[[i]]) && !is.null(meta1[[i]])) {
-          if (!is.null(attributes(meta0[[i]])$yml_type) && attributes(meta0[[i]])$yml_type == "seq") {
-            meta1[[i]] = as.list(meta1[[i]])
-          }
-        }
-      } else {
-        if (identical(attr(meta1[[i]], "yml_type"), "seq")) {
-          meta1[[i]] = as.list(meta1[[i]])
-        }
+      if (identical(attr(meta1[[i]], "yml_type"), "seq")) {
+        meta1[[i]] = as.list(meta1[[i]])
       }
     }
     yml = as.yaml(meta1)

--- a/R/utils.R
+++ b/R/utils.R
@@ -460,11 +460,13 @@ append_yaml = function(x, value = list()) {
 # particular order, and optionally remove empty fields
 modify_yaml = function(
   file, ..., .order = character(), .keep_fields = NULL,
-  .keep_empty = getOption('blogdown.yaml.empty', TRUE)
+  .keep_empty = getOption('blogdown.yaml.empty', TRUE),
+  .keep_seq = TRUE
 ) {
   x = readUTF8(file)
   res = split_yaml_body(x)
   if (length(yml <- res$yaml) > 2) {
+    meta0 = res$yaml_list
     meta1 = res$yaml_list
     meta2 = list(...)
     for (i in names(meta2)) {
@@ -480,8 +482,16 @@ modify_yaml = function(
     if (!.keep_empty) meta1 = filter_list(meta1)
     if (is.null(meta1[['draft']])) meta1$draft = NULL
     for (i in names(meta1)) {
-      if (identical(attr(meta1[[i]], 'yml_type'), 'seq')) {
-        meta1[[i]] = as.list(meta1[[i]])
+      if (.keep_seq) {
+        if (!is.null(meta0[[i]]) && !is.null(meta1[[i]])) {
+          if (!is.null(attributes(meta0[[i]])$yml_type) && attributes(meta0[[i]])$yml_type == "seq") {
+            meta1[[i]] = as.list(meta1[[i]])
+          }
+        }
+      } else {
+        if (identical(attr(meta1[[i]], "yml_type"), "seq")) {
+          meta1[[i]] = as.list(meta1[[i]])
+        }
       }
     }
     yml = as.yaml(meta1)


### PR DESCRIPTION
Dear 益辉，
为了能更好的描述这个问题，我选择了中文。这个问题是在批量修改COS文章分类的时候遇到的。读了源码，找到了罪魁祸首。问题如下：目前我们的categories选项都是以sequence的形式写的，即便只有一个。因此，当只有一个的时候，即便没有修改对应的值，yaml也会自动的把值写在冒号后面，也就是所谓的key: value的映射形式。这样在git提交的时候无疑多出了很多不必要的信息，不够干净。因此，我做了点小修改，可能看起来代码不够简洁，不过我可以继续修改到满意为止。test_it里面也没有测试到这个边缘case，之后可以加上。

不知道我说的对不对，请批评～～～ 😄

这次樱桃终于摘对了。。。。希望不被国际友人嘲笑