### PR TITLE
Resolve issues about archetypes and new posts with a non-default `kind`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: blogdown
 Type: Package
 Title: Create Blogs and Websites with R Markdown
-Version: 0.5.5
+Version: 0.5.6
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Beilei", "Bian", role = "ctb"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ Authors@R: c(
     person("Hiroaki", "Yutani", role = "ctb"),
     person("JJ", "Allaire", role = "ctb"),
     person("Kevin", "Ushey", role = "ctb"),
+    person("Leonardo", "Collado-Torres", role = "ctb"),
     person(family = "RStudio Inc", role = "cph"),
     person()
     )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: blogdown
 Type: Package
 Title: Create Blogs and Websites with R Markdown
-Version: 0.5.4
+Version: 0.5.5
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Beilei", "Bian", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - `default_kind()` now looks for the archetype matching the content. For `/content/post/2018-02-24-postslug.Rmd` it looks for `archetypes/post.md` (thanks, @lcolladotor, #173).
 
+- `new_content()` now works with files that end in .Rmd and .Rmarkdown. The archetype still has to end in .md for hugo to work with it (thanks, @lcolladotor, #261).
+
 # CHANGES IN blogdown VERSION 0.5
 
 ## BUG FIXES

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,8 +8,6 @@
 
 ## BUG FIXES
 
-- `default_kind()` now looks for the archetype matching the content. For `/content/post/2018-02-24-postslug.Rmd` it looks for `archetypes/post.md` (thanks, @lcolladotor, #173).
-
 - `new_content()` now works with files that end in .Rmd and .Rmarkdown. The archetype still has to end in .md for hugo to work with it (thanks, @lcolladotor, #261).
 
 # CHANGES IN blogdown VERSION 0.5

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@
 
 - Added a `title_case` argument to the `new_post()` function; if \code{TRUE}, the post title will be converted to title case. See `?blogdown::new_post` for details.
 
+- The `new_post` addin now lets you choose an archetype. See https://gohugo.io/content-management/archetypes/ for more details (thanks, @lcolladotor, #173).
+
+## BUG FIXES
+
+- `default_kind()` now looks for the archetype matching the content. For `/content/post/2018-02-24-postslug.Rmd` it looks for `archetypes/post.md` (thanks, @lcolladotor, #173).
+
 # CHANGES IN blogdown VERSION 0.5
 
 ## BUG FIXES

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -217,10 +217,8 @@ new_content = function(path, kind = 'default', open = interactive()) {
 default_kind = function(path) {
   path = normalizePath(path, '/', mustWork = FALSE)
   if (!grepl('/', path)) return('default')
-  ## Assumes path is something like
-  ## /pathToBlogdownDir/content/post/2018-02-24-postslug.Rmd
+  ## Assumes path is something like post/2018-02-24-postslug.Rmd
   ## (file termination doesn't matter)
-  if(!grepl('/content/', path)) return('default')
   atype = gsub('.*/', '', dirname(path))
   if (!file.exists(file.path('archetypes', paste0(atype, '.md')))) return('default')
   atype

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -190,20 +190,12 @@ install_theme = function(theme, theme_example = FALSE, update_config = TRUE, for
 #'   (e.g. a post or a page).
 new_content = function(path, kind = 'default', open = interactive()) {
   if (missing(kind)) kind = default_kind(path)
-  ## Hugo doesn't work well with non .md file terminations
-  ## So for those cases we will temporarely change the file termination
-  ## to md, run hugo, then change back the file termination.
-  path_temp = gsub(paste0(tools::file_ext(path), '$'), 'md', path)
-  file.copy(path, path_temp)
-  if(path_temp != path) on.exit(unlink(path_temp), add = TRUE)
-  hugo_cmd(c('new', shQuote(path_temp), c('-k', kind)))
-
-  file_temp = content_file(path_temp)
-  if(path_temp != path) on.exit(unlink(file_temp), add = TRUE)
-  ## If we do this after fixing the file termination it doesn't work
-  hugo_toYAML(file_temp)
-  file = gsub('md$', tools::file_ext(path), file_temp)
-  file.copy(file_temp, file)
+  path2 = with_ext(path, '.md')
+  file  = content_file(path)
+  file2 = content_file(path2)
+  hugo_cmd(c('new', shQuote(path2), c('-k', kind)))
+  hugo_toYAML(file2)
+  file.rename(file2, file)
   if (open) open_file(file)
   file
 }

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -203,11 +203,9 @@ new_content = function(path, kind = 'default', open = interactive()) {
 default_kind = function(path) {
   path = normalizePath(path, '/', mustWork = FALSE)
   if (!grepl('/', path)) return('default')
-  ## Assumes path is something like post/2018-02-24-postslug.Rmd
-  ## (file termination doesn't matter)
-  atype = gsub('.*/', '', dirname(path))
-  if (!file.exists(file.path('archetypes', paste0(atype, '.md')))) return('default')
-  atype
+  atype = gsub('/.*', '.md', path)
+  if (!file.exists(file.path('archetypes', atype))) return('default')
+  gsub('/.*', '', path)
 }
 
 # Hugo cannot convert a single file: https://github.com/gohugoio/hugo/issues/3632

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -190,26 +190,20 @@ install_theme = function(theme, theme_example = FALSE, update_config = TRUE, for
 #'   (e.g. a post or a page).
 new_content = function(path, kind = 'default', open = interactive()) {
   if (missing(kind)) kind = default_kind(path)
-  if(!grepl('\\.md$', path)) {
-    ## Hugo doesn't work well with non .md file terminations
-    ## So in this case we will temporarely change the file termination
-    ## to md, run hugo, then change back the file termination.
-    path_temp = gsub(paste0(tools::file_ext(path), '$'), 'md', path)
-    file.copy(path, path_temp)
-    on.exit(unlink(path_temp), add = TRUE)
-    hugo_cmd(c('new', shQuote(path_temp), c('-k', kind)))
+  ## Hugo doesn't work well with non .md file terminations
+  ## So for those cases we will temporarely change the file termination
+  ## to md, run hugo, then change back the file termination.
+  path_temp = gsub(paste0(tools::file_ext(path), '$'), 'md', path)
+  file.copy(path, path_temp)
+  if(path_temp != path) on.exit(unlink(path_temp), add = TRUE)
+  hugo_cmd(c('new', shQuote(path_temp), c('-k', kind)))
 
-    cont_temp = content_file(path_temp)
-    on.exit(unlink(cont_temp), add = TRUE)
-    ## If we do this after fixing the file termination it doesn't work
-    hugo_toYAML(cont_temp)
-    file = gsub('md$', tools::file_ext(path), cont_temp)
-    file.copy(cont_temp, file)
-  } else {
-    hugo_cmd(c('new', shQuote(path), c('-k', kind)))
-    file = content_file(path)
-    hugo_toYAML(file)
-  }
+  file_temp = content_file(path_temp)
+  if(path_temp != path) on.exit(unlink(file_temp), add = TRUE)
+  ## If we do this after fixing the file termination it doesn't work
+  hugo_toYAML(file_temp)
+  file = gsub('md$', tools::file_ext(path), file_temp)
+  file.copy(file_temp, file)
   if (open) open_file(file)
   file
 }

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -200,9 +200,13 @@ new_content = function(path, kind = 'default', open = interactive()) {
 default_kind = function(path) {
   path = normalizePath(path, '/', mustWork = FALSE)
   if (!grepl('/', path)) return('default')
-  atype = gsub('/.*', '.md', path)
-  if (!file.exists(file.path('archetypes', atype))) return('default')
-  gsub('/.*', '', path)
+  ## Assumes path is something like
+  ## /pathToBlogdownDir/content/post/2018-02-24-postslug.Rmd
+  ## (file termination doesn't matter)
+  if(!grepl('/content/', path)) return('default')
+  atype = gsub('.*/', '', dirname(path))
+  if (!file.exists(file.path('archetypes', paste0(atype, '.md')))) return('default')
+  atype
 }
 
 # Hugo cannot convert a single file: https://github.com/gohugoio/hugo/issues/3632

--- a/inst/scripts/new_post.R
+++ b/inst/scripts/new_post.R
@@ -35,6 +35,12 @@ local({
         ),
         height = '70px'
       ),
+      shiny::fillRow(
+        shiny::selectInput(inputId = 'kind', label = 'Archetype',
+          choices = c('default', gsub('.md', '', dir('archetypes',
+            pattern = '\\.md$')))),
+        height = '70px'
+      ),
       miniUI::gadgetTitleBar(NULL)
     )),
     server = function(input, output, session) {
@@ -66,7 +72,8 @@ local({
           input$title, author = input$author, ext = input$format,
           categories = input$cat, tags = input$tag,
           file = gsub('[-[:space:]]+', '-', input$file),
-          slug = input$slug, subdir = input$subdir, date = input$date
+          slug = input$slug, subdir = input$subdir, date = input$date,
+          kind = input$kind
         )
         shiny::stopApp()
       })
@@ -74,6 +81,6 @@ local({
         shiny::stopApp()
       })
     },
-    stopOnCancel = FALSE, viewer = shiny::dialogViewer('New Post', height = 500)
+    stopOnCancel = FALSE, viewer = shiny::dialogViewer('New Post', height = 570)
   )
 })

--- a/inst/scripts/new_post.R
+++ b/inst/scripts/new_post.R
@@ -20,6 +20,9 @@ local({
       shiny::fillRow(
         sel_input('cat', 'Categories', meta$categories),
         sel_input('tag', 'Tags', meta$tags),
+        shiny::selectInput(inputId = 'kind', label = 'Archetype',
+          choices = c('default', gsub('.md', '', dir('archetypes',
+          pattern = '\\.md$')))),
         height = '70px'
       ),
       shiny::fillRow(
@@ -33,12 +36,6 @@ local({
           c('Markdown' = '.md', 'R Markdown (.Rmd)' = '.Rmd', 'R Markdown (.Rmarkdown)' = '.Rmarkdown'),
           selected = getOption('blogdown.ext', '.md')
         ),
-        height = '70px'
-      ),
-      shiny::fillRow(
-        shiny::selectInput(inputId = 'kind', label = 'Archetype',
-          choices = c('default', gsub('.md', '', dir('archetypes',
-            pattern = '\\.md$')))),
         height = '70px'
       ),
       miniUI::gadgetTitleBar(NULL)
@@ -81,6 +78,6 @@ local({
         shiny::stopApp()
       })
     },
-    stopOnCancel = FALSE, viewer = shiny::dialogViewer('New Post', height = 570)
+    stopOnCancel = FALSE, viewer = shiny::dialogViewer('New Post', height = 500)
   )
 })


### PR DESCRIPTION
Hi,

This pull request resolves two related issues.

It addresses https://github.com/rstudio/blogdown/issues/173#issuecomment-367888459 so that `default_kind()` can find archetypes such as `archetypes/post.md` for files like `/content/post/2018-02-24-postslug.whatever`. It also adds the option to choose the archetype from the RStudio addin as described in https://github.com/rstudio/blogdown/issues/173#issuecomment-367898999.

Next, it solves the situation described in https://github.com/rstudio/blogdown/issues/261#issue-299585638 where `new_content()` wouldn't work with a provided `kind` (archetype) if the file did not end in `.md`. 

## Screenshots of PR working

Here are two screenshots showing it all working together now. First, I use the modified RStudio addin to select the `post` archetype (which you can see in the background, contents posted later here also).

<img width="1063" alt="screen shot 2018-02-24 at 10 39 15 am" src="https://user-images.githubusercontent.com/2288213/36632135-6bd3ab8a-1950-11e8-9d63-c032a18ceae2.png">

Next is a screenshot of the resulting `.Rmd` new post file where `hugo_toYAML()` added the appropriate slug, categories and tags + the rest of the contents from the `post.md` archetype (aka, `kind = 'post'`).

<img width="625" alt="screen shot 2018-02-24 at 10 39 34 am" src="https://user-images.githubusercontent.com/2288213/36632137-77339f08-1950-11e8-920c-b87fb4e83840.png">

## `archetypes/post.md` archetype initial contents

```
    +++
    title = "{{ replace .TranslationBaseName "-" " " | title }}"
    date = {{ .Date }}
    draft = false

    # Tags and categories
    # For example, use `tags = []` for no tags, or the form `tags = ["A Tag", "Another Tag"]` for one or more tags.
    tags = []
    categories = []

    # Featured image
    # Place your image in the `static/img/` folder and reference its filename below, e.g. `image = "example.jpg"`.
    # Use `caption` to display an image caption.
    #   Markdown linking is allowed, e.g. `caption = "[Image credit](http://example.org)"`.
    # Set `preview` to `false` to disable the thumbnail in listings.
    [header]
    image = ""
    caption = ""
    preview = true
    +++


    ## Add to YAML:

    ```
    output:
      blogdown::html_page:
        toc: no
        fig_width: 5
        fig_height: 5
    ```

    jojojojo

    ```{r bibsetup, echo=FALSE, message=FALSE, warning=FALSE}
    ## Load knitcitations with a clean bibliography
    library('knitcitations')
    cleanbib()
    cite_options(hyperlink = 'to.doc', citation_format = 'text', style = 'html')

    bib <- c('knitcitations' = citation('knitcitations'),
             'blogdown' = citation('blogdown')[2])
    ```
```

## Limitations / stuff for the future

1. I didn't add a warning/error message if the `kind` has a non `.md` file termination in this PR. I realize now that this is a hugo property. In any case, I'm not sure in which of the blogdown functions such a warning would go.
1. As you can see, I don't know how to edit the archetype file so that hugo and then `hugo_toYAML()` will keep/add this part to the YAML section:

```
output:
  blogdown::html_page:
    toc: no
    fig_width: 5
    fig_height: 5
```

## Misc

* I modified the `NEWS.md` file following the syntax used previously in the file. Please feel free to edit it. For example, maybe you prefer linking to this PR instead of the issues.
* In my changes to `new_content()` I use `tools::file_ext()` which should be ok, since you have `tools` under `suggests` in the `DESCRIPTION` file.



Best,
Leo