### PR TITLE
Allow full url in `theme` arg in `install_theme` (#270)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,7 @@ Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Beilei", "Bian", role = "ctb"),
     person("Forest", "Fang", role = "ctb"),
+    person("Garrick", "Aden-Buie", role = "ctb"),
     person("Hiroaki", "Yutani", role = "ctb"),
     person("Ian", "Lyttle", role = "ctb"),
     person("JJ", "Allaire", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - The `new_post` addin now lets you choose an archetype. See https://gohugo.io/content-management/archetypes/ for more details (thanks, @lcolladotor, #173).
 
+- The `theme` argument of `install_theme()` and `new_site()` now accepts a full URL to a theme's repository zip file. This can be used to install themes from other web-based git hosts, like GitLab and Bitbucket (thanks @gadenbuie, #271).
+
 ## BUG FIXES
 
 - The `kind` argument (i.e., the archetype) of `new_content()` now works with files that end in `.Rmd` and `.Rmarkdown`. The archetype still has to end in `.md` for Hugo to work with it (thanks, @lcolladotor, #261).

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -169,7 +169,6 @@ install_theme = function(
     zipdir = dirname(files)
     zipdir = zipdir[which.min(nchar(zipdir))]
     expdir = file.path(zipdir, 'exampleSite')
-    zipdir = gsub(tmpdir, ".", zipdir)
     if (dir_exists(expdir)) if (theme_example) {
       file.copy(list.files(expdir, full.names = TRUE), '../', recursive = TRUE)
       # remove the themesDir setting; it is unlikely that you need it
@@ -179,15 +178,16 @@ install_theme = function(
       'and at least take a look at the config file config.toml of the example site, ',
       'because not all Hugo themes work with any config files.'
     )
-    newdir = gsub(sprintf('-%s$', branch), '', zipdir)
+    newdir = gsub(tmpdir, ".", zipdir)
+    newdir = gsub(sprintf('-%s$', branch), '', newdir)
     if (!force && dir_exists(newdir)) stop(
       'The theme already exists. Try install_theme("', theme, '", force = TRUE) ',
       'after you read the help page ?blogdown::install_theme.', call. = FALSE
     )
     unlink(newdir, recursive = TRUE)
-    file.rename(file.path(tmpdir, zipdir), newdir)
+    file.rename(zipdir, newdir)
     unlink(zipfile)
-    if (theme_is_url) theme = zipdir
+    if (theme_is_url) theme = newdir
   })
   if (update_config) {
     change_config('theme', sprintf('"%s"', basename(theme)))

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -167,9 +167,9 @@ install_theme = function(
     on.exit(in_dir('themes', unlink(tmpdir, recursive = TRUE)))
     files = utils::unzip(zipfile, exdir = tmpdir)
     zipdir = dirname(files)
-    zipdir = gsub(tmpdir, ".", zipdir)
     zipdir = zipdir[which.min(nchar(zipdir))]
     expdir = file.path(zipdir, 'exampleSite')
+    zipdir = gsub(tmpdir, ".", zipdir)
     if (dir_exists(expdir)) if (theme_example) {
       file.copy(list.files(expdir, full.names = TRUE), '../', recursive = TRUE)
       # remove the themesDir setting; it is unlikely that you need it

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -151,7 +151,7 @@ install_theme = function(
     return(invisible())
   }
   branch = sub('^@', '', gsub(r, '\\2', theme))
-  if (branch == '') branch = 'master'
+  if (branch == '' | theme_is_url) branch = 'master'
   theme = gsub(r, '\\1', theme)
   dir_create('themes')
   in_dir('themes', {
@@ -179,6 +179,7 @@ install_theme = function(
       'because not all Hugo themes work with any config files.'
     )
     newdir = gsub(tmpdir, ".", zipdir)
+    newdir = gsub("-[a-f0-9]{12,40}$", "", newdir)
     newdir = gsub(sprintf('-%s$', branch), '', newdir)
     if (!force && dir_exists(newdir)) stop(
       'The theme already exists. Try install_theme("', theme, '", force = TRUE) ',

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -76,12 +76,14 @@ change_config = function(name, value) {
 #' @param sample Whether to add sample content. Hugo creates an empty site by
 #'   default, but this function adds sample content by default).
 #' @param theme A Hugo theme on Github (a chararacter string of the form
-#'   \code{user/repo}, and you can optionally sepecify a GIT branch or tag name
+#'   \code{user/repo}, and you can optionally specify a GIT branch or tag name
 #'   after \code{@@}, i.e. \code{theme} can be of the form
-#'   \code{user/repo@@branch}). If \code{theme = NA}, no themes will be
-#'   installed, and you have to manually install a theme.
+#'   \code{user/repo@@branch}). You can also specify a full URL to the zip file of
+#'   the theme. If \code{theme = NA}, no themes will be installed, and you have
+#'   to manually install a theme.
 #' @param hostname Where to find the theme. Defaults to \code{github.com}; specify
-#'   if you wish to use an instance of GitHub Enterprise.
+#'   if you wish to use an instance of GitHub Enterprise. You can also specify the
+#'   full URL of the zip file in \code{theme}, in which case this argument is ignored.
 #' @param theme_example Whether to copy the example in the \file{exampleSite}
 #'   directory if it exists in the theme. Not all themes provide example sites.
 #' @param serve Whether to start a local server to serve the site.
@@ -142,8 +144,10 @@ install_theme = function(
   theme, hostname = 'github.com', theme_example = FALSE, update_config = TRUE, force = FALSE
 ) {
   r = '^([^/]+/[^/@]+)(@.+)?$'
-  if (!is.character(theme) || length(theme) != 1 || !grepl(r, theme)) {
-    warning("'theme' must be a character string of the form 'user/repo' or 'user/repo@branch'")
+  r_zip = "\\.zip$"
+  theme_is_url = grepl(r_zip, theme)
+  if (!is.character(theme) || length(theme) != 1 || (!grepl(r, theme) & !theme_is_url)) {
+    warning("'theme' must be a character string of the form 'user/repo' or 'user/repo@branch', or a full URL to the .zip file")
     return(invisible())
   }
   branch = sub('^@', '', gsub(r, '\\2', theme))
@@ -151,8 +155,13 @@ install_theme = function(
   theme = gsub(r, '\\1', theme)
   dir_create('themes')
   in_dir('themes', {
-    url = sprintf('https://%s/%s/archive/%s.zip', hostname, theme, branch)
-    zipfile = sprintf('%s.zip', basename(theme))
+    if (theme_is_url) {
+      url = theme
+      zipfile = gsub(".+/(.+\\.zip)", "\\1", theme)
+    } else {
+      url = sprintf('https://%s/%s/archive/%s.zip', hostname, theme, branch)
+      zipfile = sprintf('%s.zip', basename(theme))
+    }
     download2(url, zipfile, mode = 'wb')
     files = utils::unzip(zipfile)
     zipdir = dirname(files)
@@ -167,13 +176,17 @@ install_theme = function(
       'and at least take a look at the config file config.toml of the example site, ',
       'because not all Hugo themes work with any config files.'
     )
-    newdir = gsub(sprintf('-%s$', branch), '', zipdir)
-    if (!force && dir_exists(newdir)) stop(
-      'The theme already exists. Try install_theme("', theme, '", force = TRUE) ',
-      'after you read the help page ?blogdown::install_theme.', call. = FALSE
-    )
-    unlink(newdir, recursive = TRUE)
-    file.rename(zipdir, newdir)
+    if (!theme_is_url) {
+      newdir = gsub(sprintf('-%s$', branch), '', zipdir)
+      if (!force && dir_exists(newdir)) stop(
+        'The theme already exists. Try install_theme("', theme, '", force = TRUE) ',
+        'after you read the help page ?blogdown::install_theme.', call. = FALSE
+      )
+      unlink(newdir, recursive = TRUE)
+      file.rename(zipdir, newdir)
+    } else {
+      theme = zipdir
+    }
     unlink(zipfile)
   })
   if (update_config) {

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -151,7 +151,7 @@ install_theme = function(
     return(invisible())
   }
   branch = sub('^@', '', gsub(r, '\\2', theme))
-  if (branch == '' | theme_is_url) branch = 'master'
+  if (branch == '' || theme_is_url) branch = 'master'
   theme = gsub(r, '\\1', theme)
   dir_create('themes')
   in_dir('themes', {


### PR DESCRIPTION
This PR allows the `theme` argument in `new_site()` and `install_theme()` to accept a full URL to the zip file of the theme, in line with the discussions in #264 and #270.

Some notes:

I did not add any validation on the URL other than to check that it ends in `.zip`. This lets the process be as flexible as possible and `download2()` will throw the error if the URL is invalid or doesn't work. This also means the user can specify a local file, like `file:///home/user/archive.zip` or any other unusual configuration.

 Because I didn't attempt to guess at the structure of the URL, we don't know the theme's base name and we have to rely on the first level folder in the zip file. This is in line with how `install_theme()` currently works, but previously you used knowledge of the `branch` (parsed from the `theme` argument) to remove the trailing `-<branch>` from the theme name. The end result here is that the theme may end up with a long, unique name depending on how it's zipped by the repo host, but this will be transparent to the user (no warning or message emitted).

To illustrate the process, in the use case described in #270, 

1. the full URL is <https://gitlab.com/syui/hugo-theme-wave/repository/master/archive.zip>,

2. the theme is downloaded, extracted and stored in `themes/hugo-theme-wave-master-13b859a257213881038ebeb1021a5578c243653b` 

3. and the config file is changed to `theme = "hugo-theme-wave-master-13b859a257213881038ebeb1021a5578c243653b"`

Finally, there is the question of `force = TRUE`. Sticking to minimal changes, specifying the full URL is equivalent to `force = TRUE` because the folder name is only changed using the `user/repo` style name. Previously, you were reasonably certain that the zip file would extract into a different folder than the final folder, so there aren't any checks that the unzipping will overwrite. This is the expected behavior in d198998.

I added a second commit, 4bda539, where the zip file is extracted into a temp folder inside `themes/`. The `tmpdir` name is stripped from the zip file list so that we still get the theme folder, and if `force = FALSE` and the theme dir (`zipdir`) exists inside `themes/` the error is thrown,  `tmpdir` is unlinked, and the zip file remains (as this was the previous behavior). I've separated this into a second commit so that you can see behavior with and without the usage of a `tmpdir`. Feel free to revert or ask for changes as needed.

p.s. will be happy to add news entry and finalize PR, etc. after your review.