### PR TITLE
v0.5.10 -- allows using baseurl in the Insert Image addin

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: blogdown
 Type: Package
 Title: Create Blogs and Websites with R Markdown
-Version: 0.5.9
+Version: 0.5.10
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Beilei", "Bian", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 - The `new_post` addin now lets you choose an archetype. See https://gohugo.io/content-management/archetypes/ for more details (thanks, @lcolladotor, #173).
 
-- Added a new RStudio addin (`insert_image`) for inserting external images into blog posts (thanks, @lcolladotor, #269).
+- Added a new RStudio addin (`insert_image`) for inserting external images into blog posts (thanks, @lcolladotor, #269). By default it uses the baseurl so that RSS feeds will include the images and be properly displayed in websites such as RBloggers (#275). You will need to publish the images so that they are displayed in a local preview.
 
 - The `theme` argument of `install_theme()` and `new_site()` now accepts a full URL to a theme's repository zip file. This can be used to install themes from other web-based git hosts, like GitLab and Bitbucket (thanks, @gadenbuie, #271).
 

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -21,6 +21,10 @@ local({
       shiny::fillRow(
         txt_input('w', 'Width', '', '(optional) e.g., 400px or 80%'),
         txt_input('h', 'Height', '', '(optional) e.g., 200px'),
+        shiny::column(width = 1, offset = 1, shiny::radioButtons(
+          'usebaseurl', 'Use base url in links?',
+          inline = TRUE, c('Yes' = TRUE, 'No' = FALSE), selected = TRUE
+        )),
         height = '70px'
       ),
       shiny::fillRow(
@@ -65,7 +69,9 @@ local({
 
         image_code = function() {
           s = paste0(
-            "/", basename(dirname(target_dir)), "/",
+            ifelse(as.logical(input$usebaseurl),
+              blogdown:::load_config()$baseurl, "/"),
+            basename(dirname(target_dir)), "/",
             basename(target_dir), "/", basename(input$target)
           )
           w = input$w; h = input$h; alt = input$alt


### PR DESCRIPTION
Hi Yihui,

This is a minor tweak to the _Insert Image_ addin. Basically, I was running into an issue where the RSS feed of my blog didn't display the images, which lead to RBloggers and other places that use the RSS to be incomplete/ugly.

Using the `baseurl` however does mess with the local preview, since you need to make the images public before they are displayed in a local preview. So if a user chooses "no", they can later manually edit the links if they want. 

Current display:
<img width="620" alt="screen shot 2018-03-10 at 10 41 41 am" src="https://user-images.githubusercontent.com/2288213/37243942-a7b5a77a-244f-11e8-9fd5-304c167beb84.png">


Best,
Leo

