### PR TITLE
Fix backslash issue when using tmpdir as regexp on Windows in install_theme

### DIFF
--- a/R/hugo.R
+++ b/R/hugo.R
@@ -178,7 +178,8 @@ install_theme = function(
       'and at least take a look at the config file config.toml of the example site, ',
       'because not all Hugo themes work with any config files.'
     )
-    newdir = gsub(tmpdir, ".", zipdir)
+    # tmpdir on Windows is ".\\dir" but is "./dir" in zipdir
+    newdir = gsub(gsub("\\\\", "/", tmpdir), ".", zipdir)
     newdir = gsub("-[a-f0-9]{12,40}$", "", newdir)
     newdir = gsub(sprintf('-%s$', branch), '', newdir)
     if (!force && dir_exists(newdir)) stop(


### PR DESCRIPTION
As reported at <https://stackoverflow.com/questions/49212335/r-blogdown-new-site-throws-error>, the use of the `tempfile()` result as a regexp in `install_theme()` causes problems on Windows.

What I found was that `tmpdir = tempfile("", ".")` returns a string like `".\\dir"`, whereas the filenames returned by `utils::unzip(..., exdir = tmpdir)` are `"./dir/zip_base_dir`.

For example:

```r
Browse[2]> tmpdir
[1] ".\\2a0c6c64f7e"
Browse[2]> zipdir
[1] "./2a0c6c64f7e/hugo-lithium-theme-master"
```

This PR replaces the double backslash with a single forward slash when stripping the `tmpdir` prefix from `zipdir` and seems to work on Windows and Unix-alike (where there are no backslashes to match).

<details><summary>Session info for Windows test</summary>

```
> sessioninfo::session_info()
─ Session info ──────────────────────────────────────────────────────────────────────────────
 setting  value                       
 version  R version 3.4.0 (2017-04-21)
 os       Windows 7 x64 SP 1          
 system   x86_64, mingw32             
 ui       RStudio                     
 language (EN)                        
 collate  English_United States.1252  
 tz       America/New_York            
 date     2018-03-11                  

─ Packages ──────────────────────────────────────────────────────────────────────────────────
 package     * version date       source        
 backports     1.0.5   2017-01-18 CRAN (R 3.4.0)
 blogdown    * 0.5.9   <NA>       local         
 bookdown      0.7     2018-02-18 CRAN (R 3.4.3)
 clisymbols    1.2.0   2017-05-21 CRAN (R 3.4.3)
 commonmark    1.4     2017-09-01 CRAN (R 3.4.3)
 devtools      1.13.5  2018-02-18 CRAN (R 3.4.3)
 digest        0.6.15  2018-01-28 CRAN (R 3.4.3)
 evaluate      0.10    2016-10-11 CRAN (R 3.4.0)
 htmltools     0.3.6   2017-04-28 CRAN (R 3.4.3)
 httpuv        1.3.6.2 2018-03-02 CRAN (R 3.4.3)
 knitr         1.20    2018-02-20 CRAN (R 3.4.3)
 later         0.7.1   2018-03-07 CRAN (R 3.4.3)
 magrittr      1.5     2014-11-22 CRAN (R 3.4.0)
 memoise       1.1.0   2017-04-21 CRAN (R 3.4.0)
 mime          0.5     2016-07-07 CRAN (R 3.4.0)
 R6            2.2.2   2017-06-17 CRAN (R 3.4.3)
 Rcpp          0.12.10 2017-03-19 CRAN (R 3.4.0)
 RcppTOML      0.1.3   2017-04-25 CRAN (R 3.4.3)
 rlang         0.2.0   2018-02-20 CRAN (R 3.4.3)
 rmarkdown     1.9     2018-03-01 CRAN (R 3.4.3)
 roxygen2      6.0.1   2017-02-06 CRAN (R 3.4.3)
 rprojroot     1.2     2017-01-16 CRAN (R 3.4.0)
 rstudioapi    0.7     2017-09-07 CRAN (R 3.4.3)
 servr         0.8     2017-11-06 CRAN (R 3.4.3)
 sessioninfo   1.0.0   2017-06-21 CRAN (R 3.4.3)
 stringi       1.1.6   2017-11-17 CRAN (R 3.4.2)
 stringr       1.3.0   2018-02-19 CRAN (R 3.4.3)
 withr         2.1.1   2017-12-19 CRAN (R 3.4.3)
 xfun          0.1     2018-01-22 CRAN (R 3.4.3)
 xml2          1.2.0   2018-01-24 CRAN (R 3.4.3)
 yaml          2.1.18  2018-03-08 CRAN (R 3.4.3)
```
</details>