### PR TITLE
Insert image in format consistent with pandoc

### DIFF
--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -86,7 +86,10 @@ local({
               if (x == '') return(x)
               tryCatch(
                 htmltools::validateCssUnit(x),
-                error = function(e) warning(e$message, call. = FALSE)
+                error = function(e) {
+                  warning(e$message, call. = FALSE)
+                  return(x)
+                }
               )
             }
             w = safely_validateCssUnit(w)

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -82,31 +82,16 @@ local({
           if (w == '' && h == '') {
             paste0('![', alt, '](', s, ')')
           } else {
+            safely_validateCssUnit = function(x) {
+              if (x == '') return(x)
+              tryCatch(
+                htmltools::validateCssUnit(x),
+                error = function(e) warning(e$message, call. = FALSE)
+              )
+            }
+            w = safely_validateCssUnit(w)
+            h = safely_validateCssUnit(h)
             if (ctx_ext == "rmd") {
-              check_pandoc_format = function(x) {
-                warn_text = c()
-                x = gsub(" ", "", x)
-                if (x != "" && !grepl("^\\d", x)){
-                  warn_text = c(warn_text,
-                    "attributes must start with a number, followed by unit without spaces")
-                }
-                units = gsub("^\\d+(.+)", "\\1", x)
-                if (units != "") {
-                  if (!units %in% c("px", "cm", "mm", "in", "inch", "%")) {
-                    warn_text = c(warn_text,
-                      "unit must be one of `px`, `cm`, `mm`, `in`, `inch`, or `%`")
-                  }
-                }
-                if (length(warn_text)) {
-                  warn_text = paste(warn_text, collapse = " and ")
-                  warn_text = paste0("Please review the attributes of the inserted image source.\nWidth/height ",
-                                     warn_text)
-                  warning(warn_text, call. = FALSE)
-                }
-                x
-              }
-              w = check_pandoc_format(w)
-              h = check_pandoc_format(h)
               paste0('![', alt, '](', s, '){',
                        if (w != '') paste0('width=', w),
                        if (h != '') paste0(' height=', h),

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -83,6 +83,30 @@ local({
             paste0('![', alt, '](', s, ')')
           } else {
             if (ctx_ext == "rmd") {
+              check_pandoc_format = function(x) {
+                warn_text = c()
+                x = gsub(" ", "", x)
+                if (x != "" && !grepl("^\\d", x)){
+                  warn_text = c(warn_text,
+                    "attributes must start with a number, followed by unit without spaces")
+                }
+                units = gsub("^\\d+(.+)", "\\1", x)
+                if (units != "") {
+                  if (!units %in% c("px", "cm", "mm", "in", "inch", "%")) {
+                    warn_text = c(warn_text,
+                      "unit must be one of `px`, `cm`, `mm`, `in`, `inch`, or `%`")
+                  }
+                }
+                if (length(warn_text)) {
+                  warn_text = paste(warn_text, collapse = " and ")
+                  warn_text = paste0("Please review the attributes of the inserted image source.\nWidth/height ",
+                                     warn_text)
+                  warning(warn_text, call. = FALSE)
+                }
+                x
+              }
+              w = check_pandoc_format(w)
+              h = check_pandoc_format(h)
               paste0('![', alt, '](', s, '){',
                        if (w != '') paste0('width=', w),
                        if (h != '') paste0(' height=', h),

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -63,15 +63,26 @@ local({
         )
         if (copy_check) message('Successfully copied the image to ', input$target)
 
+        figure_code = function(src, alt = '', w = '', h = '') {
+          paste0(
+            '<div class="figure">\n',
+            '<img src="', src, '"',
+            ' alt="', alt, '"',
+            if (w != '') paste0(' width="', w, '"'),
+            if (h != '') paste0(' height="', h, '"'),
+            "/>\n",
+            if (alt != '') paste0('<p class="caption">', alt, "</p>\n"),
+            "</div>"
+          )
+        }
+
         image_code = function() {
           s = paste0(
             "/", basename(dirname(target_dir)), "/",
             basename(target_dir), "/", basename(input$target)
           )
           w = input$w; h = input$h; alt = input$alt
-          if (w == '' && h == '') paste0('![', alt, '](', s, ')') else shiny::img(
-            src = s, alt = alt, width = if (w != '') w, height = if (h != '') h
-          )
+          if (w == '' && h == '') paste0('![', alt, '](', s, ')') else figure_code(s, alt, w, h)
         }
 
         rstudioapi::insertText(as.character(image_code()), id = ctx$id)

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -79,7 +79,7 @@ local({
                 htmltools::validateCssUnit(x),
                 error = function(e) {
                   warning(e$message, call. = FALSE)
-                  return(x)
+                  x
                 }
               )
             }

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -5,16 +5,7 @@ local({
   if (ctx$path == '') stop(
     'Please select the blog post source file before using this addin', call. = FALSE
   )
-  ctx_ext = switch(
-    tolower(xfun::file_ext(ctx$path)),
-    "rmd" = "rmd",
-    "md" = "md",
-    "rmarkdown" = "md",
-    stop(
-      "Please select a blog post source file with extension `.Rmd`, `.md`, or `.Rmarkdown`.",
-      call. = FALSE
-    )
-  )
+  ctx_ext = tolower(xfun::file_ext(ctx$path))
 
   path = normalizePath(ctx$path)
   imgdir = file.path(
@@ -100,7 +91,6 @@ local({
                        if (h != '') paste0(' height=', h),
                      '}')
             } else {
-              # ctx_ext == md or Rmarkdown
               shiny::img(src = s, alt = alt, width = if (w != '') w, height = if (h != '') h)
             }
           }


### PR DESCRIPTION
First, thank you @lcolladotor, the Insert Image addin is 💯 👍 

I noticed that the addin uses `shiny::img()` to create the HTML img tag when width or height are set in the addin. When `height` or `width` are not set, though, the addin uses standard markdown format of `![alt](src)`, which when processed by pandoc is converted to

```html
<div class="figure">
<img src="{{src}}" alt="{{alt}}"/>
<p class="caption">{{alt}}</p>
</div>
```

Using `shiny::img()` then has the side effect of removing the caption and results in an image with slightly different formatting.

This PR adds the function `figure_code()` to the Insert Image addin that adds width or height into the `<img>` tag inside the figure `div` to be consistent with pandoc's `![]()` processing.

For example, inserting an image and setting the width or height param using the gadget

![screenshot 2018-03-15 23 29 09](https://user-images.githubusercontent.com/5420529/37502946-0712c940-28ac-11e8-9b04-eb40fc6e7a5f.png)

now inserts this code in the `.Rmd` (`.md`) and the `.html` file.

```html
<div class="figure">
<img src="/post/2018-03-15-test-insert-image_files/hadley_typing2.gif" alt="Hadley Typing (width set)" width="50%"/>
<p class="caption">Hadley Typing (width set)</p>
</div>
```

Not setting width results in this in the `.Rmd` file

```md
![Hadley Typing (w/h not set)](/post/2018-03-15-test-insert-image_files/hadley_typing.gif)
```

which is converted by pandoc to this in the `.html`

```html
<div class="figure">
<img src="/post/2018-03-15-test-insert-image_files/hadley_typing.gif" alt="Hadley Typing (w/h not set)" />
<p class="caption">Hadley Typing (w/h not set)</p>
</div>
```

For reference, this was the previous output of the insert image addin

```html
<img src="/post/2018-03-15-test-insert-image_files/hadley_typing2.gif" alt="Hadley Typing (shiny::img)" width="33%"/>
```

And they all look good in the final post

![screenshot 2018-03-15 23 57 06](https://user-images.githubusercontent.com/5420529/37503102-d4ea6864-28ac-11e8-8897-19b705d5a416.png)
