### PR TITLE
Allow baseurl insert image v2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: blogdown
 Type: Package
 Title: Create Blogs and Websites with R Markdown
-Version: 0.5.11
+Version: 0.5.12
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Beilei", "Bian", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 - The `new_post` addin now lets you choose an archetype. See https://gohugo.io/content-management/archetypes/ for more details (thanks, @lcolladotor, #173).
 
-- Added a new RStudio addin (`insert_image`) for inserting external images into blog posts (thanks, @lcolladotor, #269).
+- Added a new RStudio addin (`insert_image`) for inserting external images into blog posts (thanks, @lcolladotor, #269). If you use options(blogdown.insertimage.usebaseurl = TRUE) then it adds the baseurl so that RSS feeds will include the images and be properly displayed in websites such as RBloggers (#275). You will need to publish the images so that they are displayed in a local preview and will need to keep in mind some drawbacks discussed in https://github.com/rstudio/blogdown/pull/275.
 
 - The `theme` argument of `install_theme()` and `new_site()` now accepts a full URL to a theme's repository zip file. This can be used to install themes from other web-based git hosts, like GitLab and Bitbucket (thanks, @gadenbuie, #271).
 

--- a/docs/01-introduction.Rmd
+++ b/docs/01-introduction.Rmd
@@ -140,6 +140,7 @@ knitr::kable(matrix(c(
   'blogdown.ext', '.md', 'Default extension of new posts',
   'blogdown.subdir', 'post', 'A subdirectory under content/',
   'blogdown.yaml.empty', TRUE, 'Preserve empty fields in YAML?',
+  'blogdown.insertimage.usebaseurl', FALSE, 'Use the base url when inserting images?',
   NULL
 ), ncol = 3, byrow = TRUE, dimnames = list(NULL, c('Option name', 'Default', 'Meaning'))), booktabs = TRUE, caption = 'Global options that affect the behavior of blogdown.')
 ```

--- a/docs/01-introduction.Rmd
+++ b/docs/01-introduction.Rmd
@@ -140,7 +140,6 @@ knitr::kable(matrix(c(
   'blogdown.ext', '.md', 'Default extension of new posts',
   'blogdown.subdir', 'post', 'A subdirectory under content/',
   'blogdown.yaml.empty', TRUE, 'Preserve empty fields in YAML?',
-  'blogdown.insertimage.usebaseurl', FALSE, 'Use the base url when inserting images?',
   NULL
 ), ncol = 3, byrow = TRUE, dimnames = list(NULL, c('Option name', 'Default', 'Meaning'))), booktabs = TRUE, caption = 'Global options that affect the behavior of blogdown.')
 ```

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -73,7 +73,9 @@ local({
         }
         image_code = function() {
           s = paste0(
-            "/", basename(dirname(target_dir)), "/",
+            ifelse(getOption('blogdown.insertimage.usebaseurl', FALSE),
+              blogdown:::load_config()$baseurl, "/"),
+            basename(dirname(target_dir)), "/",
             basename(target_dir), "/", basename(input$target)
           )
           w = input$w; h = input$h; alt = input$alt

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -20,13 +20,8 @@ local({
         height = '90px'
       ),
       shiny::fillRow(
-        txt_input('w', 'Width', '', '(optional) e.g., 400px'),
-        txt_input('h', 'Height', '', '(optional) e.g., 80%'),
-        shiny::column(width = 1, offset = 1, shiny::radioButtons(
-          'usebaseurl', 'Use base url in links?',
-          inline = TRUE, c('Yes' = TRUE, 'No' = FALSE),
-          selected = getOption('blogdown.insertimage.usebaseurl', FALSE)
-        )),
+        txt_input('w', 'Width', '', '(optional) e.g., 400px or 80%'),
+        txt_input('h', 'Height', '', '(optional) e.g., 200px'),
         height = '70px'
       ),
       shiny::fillRow(
@@ -78,7 +73,7 @@ local({
         }
         image_code = function() {
           s = paste0(
-            ifelse(as.logical(input$usebaseurl),
+            ifelse(getOption('blogdown.insertimage.usebaseurl', FALSE),
               blogdown:::load_config()$baseurl, "/"),
             basename(dirname(target_dir)), "/",
             basename(target_dir), "/", basename(input$target)

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -20,8 +20,13 @@ local({
         height = '90px'
       ),
       shiny::fillRow(
-        txt_input('w', 'Width', '', '(optional) e.g., 400px or 80%'),
-        txt_input('h', 'Height', '', '(optional) e.g., 200px'),
+        txt_input('w', 'Width', '', '(optional) e.g., 400px'),
+        txt_input('h', 'Height', '', '(optional) e.g., 80%'),
+        shiny::column(width = 1, offset = 1, shiny::radioButtons(
+          'usebaseurl', 'Use base url in links?',
+          inline = TRUE, c('Yes' = TRUE, 'No' = FALSE),
+          selected = getOption('blogdown.insertimage.usebaseurl', FALSE)
+        )),
         height = '70px'
       ),
       shiny::fillRow(
@@ -73,7 +78,7 @@ local({
         }
         image_code = function() {
           s = paste0(
-            ifelse(getOption('blogdown.insertimage.usebaseurl', FALSE),
+            ifelse(as.logical(input$usebaseurl),
               blogdown:::load_config()$baseurl, "/"),
             basename(dirname(target_dir)), "/",
             basename(target_dir), "/", basename(input$target)


### PR DESCRIPTION
Continues https://github.com/rstudio/blogdown/pull/275#issuecomment-375116290

This is how it looks by default:

<img width="616" alt="screen shot 2018-03-21 at 6 50 24 pm" src="https://user-images.githubusercontent.com/2288213/37741773-1e4905a2-2d39-11e8-8b06-0de62cc175d6.png">
