### PR TITLE
Suppress warning call location from install_theme

### DIFF
--- a/R/hugo.R
+++ b/R/hugo.R
@@ -176,7 +176,7 @@ install_theme = function(
     } else warning(
       "The theme has provided an example site. You should read the theme's documentation ",
       'and at least take a look at the config file config.toml of the example site, ',
-      'because not all Hugo themes work with any config files.'
+      'because not all Hugo themes work with any config files.', call. = FALSE
     )
     newdir = sub(tmpdir, '.', zipdir, fixed = TRUE)
     newdir = gsub('-[a-f0-9]{12,40}$', '', newdir)


### PR DESCRIPTION
This suppresses the warning call trace as it appears to show that it is inside of `in("themes", {` which may confusion as `install_themes()` is what the user calls. 

<img width="735" alt="screen shot 2018-03-22 at 2 55 21 pm" src="https://user-images.githubusercontent.com/833642/37795344-3926a772-2de2-11e8-8058-efc3f759fd27.png">

This also matches the use `stop()` in the next `if` statement. c.f.

https://github.com/rstudio/blogdown/compare/master...coatless:coatless-patch-1?expand=1#diff-dac531bf19fffc061cbbaa38b648ced8R186