### PR TITLE
Add `pre_knit` support to html_page()

### DIFF
--- a/R/format.R
+++ b/R/format.R
@@ -31,7 +31,7 @@
 #' @export
 html_page = function(
   ..., number_sections = FALSE, self_contained = FALSE, highlight = NULL,
-  template = NULL, post_processor = NULL
+  template = NULL, post_processor = NULL, pre_knit = NULL
 ) {
   if (identical(template, 'default')) stop(
     'blogdown::html_page() does not support template = "default"'
@@ -41,10 +41,14 @@ html_page = function(
   )
   if (is.character(post_processor))
     post_processor <- eval(parse(text = post_processor))
+  if (is.character(pre_knit)){
+    pre_knit <- eval(parse(text = pre_knit))
+  }
   rmarkdown::output_format(
     knitr = NULL,
     pandoc = NULL,
     clean_supporting = self_contained,
+    pre_knit = pre_knit,
     post_processor = post_processor,
     base_format = bookdown::html_document2(
       ..., number_sections = number_sections, theme = NULL,


### PR DESCRIPTION
## Motivation

For a long time, I have been using the [workflowr](https://jdblischak.github.io/workflowr/) package to streamline my workflow and create reproducible analyses that are easily shared. I recently discovered `blogdown`, and thought to integrate both of them into my workflow, as they both share a lot of the underlying frameworks, and complement each other nicely; `blogdown` allows me to create a powerful website, while analyses generated using `workflowr` have features such as the Reproducibility Report that do not require any additional thought on my part. However, getting them to work together proved to be more difficult than I initially anticipated.

## The Fix

By implementing a very minimal change to `blogdown::html_page`, I was able to get the features of `workflowr` into a minimal `blogdown` site. I have made a fork of `blogdown` that is [available here](https://github.com/docmanny/blogdown) where I added an option to provide a `pre_knit` function to `html_page` in the YAML in the same way that `post_processor` is handled in pull #146. 

## Pros and cons

The Pro here is that one can now declare a function in the YAML header (either through a reference or by inserting the text of the function) that can provide edits to the document before it goes through the `blogdown` pipeline. In the context of `workflowr`, by providing it with the `pre_knit` function defined in [workflowr::wflow_html](https://github.com/jdblischak/workflowr/blob/master/R/wflow_html.R), we can incorporate all the reproducibility checks without any more thought. 
I can't think of any cons to this solution, as it is so minimal, but I would welcome any input.