### PR TITLE
Add an after_build.R script for `hugo_build`

### DIFF
--- a/R/hugo.R
+++ b/R/hugo.R
@@ -29,6 +29,7 @@ hugo_build = function(local = FALSE) {
   config = load_config()
   # Hugo 0.48 generates an ugly empty resources/ dir in the root dir
   on.exit(bookdown:::clean_empty_dir('resources'), add = TRUE)
+  on.exit(run_script('R/after_build.R', as.character(local)), add = TRUE)
   hugo_cmd(c(
     if (local) c('-b', site_base_dir(), '-D', '-F'),
     '-d', shQuote(publish_dir(config)), theme_flag(config)

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -29,7 +29,7 @@ hugo_build = function(local = FALSE) {
   config = load_config()
   # Hugo 0.48 generates an ugly empty resources/ dir in the root dir
   on.exit(bookdown:::clean_empty_dir('resources'), add = TRUE)
-  on.exit(run_script('R/after_build.R', as.character(local)), add = TRUE)
+  
   hugo_cmd(c(
     if (local) c('-b', site_base_dir(), '-D', '-F'),
     '-d', shQuote(publish_dir(config)), theme_flag(config)

--- a/R/render.R
+++ b/R/render.R
@@ -45,7 +45,10 @@ build_site = function(
     files = files[mapply(require_rebuild, output_file(files), files)]
   }
   build_rmds(files)
-  if (run_hugo) on.exit(hugo_build(local), add = TRUE)
+  if (run_hugo){
+    on.exit(hugo_build(local), add = TRUE)
+    on.exit(run_script('R/after_build.R', as.character(local)), add = TRUE)
+  }
   invisible()
 }
 


### PR DESCRIPTION
Adds the option for users to use post processing script to munge the build results.

I need this for fixing paths in my RSS feed. My blog is served to a subdirectory of a github page, the URLs are
built correctly for the posts but incorrectly in the RSS feed. Changing the baseURL fixes the xml but breaks
the posts. Figured post processing was easiest. 

Even if there is an easier way to fix my particular problem, this feature would still be useful.