### PR TITLE
Support custom flags for the hugo command via hugo_build()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ Authors@R: c(
     person("Leonardo", "Collado-Torres", role = "ctb"),
     person("Xianying", "Tan", role = "ctb"),
     person("Raniere", "Silva", role = "ctb"),
+    person("Jozef", "Hajnala", role = "ctb"),
     person(family = "RStudio Inc", role = "cph"),
     person()
     )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # CHANGES IN blogdown VERSION 0.13
 
+## NEW FEATURES
 
+- Added a global option `blogdown.hugo.args`, which should be a character vector with additional flags to be passed to the `hugo` system command via `hugo_build()`. For example, `options(blogdown.hugo.args = '--minify')` will use [minification](https://gohugo.io/news/0.47-relnotes/) on the final rendered output. More available flags in the [hugo documentation](https://gohugo.io/commands/hugo#options) (thanks, @jozefhajnala, [#382](https://github.com/rstudio/blogdown/pull/382))
 
 # CHANGES IN blogdown VERSION 0.12
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## NEW FEATURES
 
-- Added a global option `blogdown.hugo.args`, which should be a character vector with additional flags to be passed to the `hugo` system command via `hugo_build()`. For example, `options(blogdown.hugo.args = '--minify')` will use [minification](https://gohugo.io/news/0.47-relnotes/) on the final rendered output. More available flags in the [hugo documentation](https://gohugo.io/commands/hugo#options) (thanks, @jozefhajnala, [#382](https://github.com/rstudio/blogdown/pull/382))
+- Added a global option `blogdown.hugo.args`, which should be a character vector with additional flags to be passed to the `hugo` system command via `hugo_build()`. For example, `options(blogdown.hugo.args = '--minify')` will use [minification](https://gohugo.io/news/0.47-relnotes/) on the final rendered output. More available flags in the [hugo documentation](https://gohugo.io/commands/hugo#options) (thanks, @jozefhajnala, #382).
 
 # CHANGES IN blogdown VERSION 0.12
 

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -32,6 +32,7 @@ hugo_build = function(local = FALSE) {
   if (local) tweak_hugo_env()
   hugo_cmd(c(
     if (local) c('-b', site_base_dir(), '-D', '-F'),
+    getOption('blogdown.hugo.args'),
     '-d', shQuote(publish_dir(config)), theme_flag(config)
   ))
 }


### PR DESCRIPTION
Since [Hugo v0.47](https://gohugo.io/news/0.47-relnotes/) there is minification support for the final rendered output. This PR proposes an option to use `--minify` when building sites with blogdown.