### PR TITLE
Normalize path on windows with / as default 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # CHANGES IN blogdown VERSION 0.15
 
+## BUG FIXES
 
+- _Insert Image_ addin now works correctly on windows. (thanks, @filippogambarota, @cderv, #397)
 
 # CHANGES IN blogdown VERSION 0.14
 

--- a/inst/scripts/insert_image.R
+++ b/inst/scripts/insert_image.R
@@ -7,7 +7,7 @@ local({
   )
   ctx_ext = tolower(xfun::file_ext(ctx$path))
 
-  path = normalizePath(ctx$path)
+  path = xfun::normalize_path(ctx$path)
   imgdir = file.path(
     'static', dirname(gsub('.*content/', '', path)),
     paste0(xfun::sans_ext(basename(path)), '_files')


### PR DESCRIPTION
This fixes #397 by changing the default winslash on windows to go with the reprex. 

Here I used `xfun::normalize_path` but we could also use `normalizePath` with `winslash = "/"`. Tell me if it is better. 

Also, normalizePath is used elsewhere in blogdown. 
Should this also be changed ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/blogdown/398)
<!-- Reviewable:end -->
