### PR TITLE
propose changes to the New Post addin

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,17 +32,18 @@ Imports:
     xfun (>= 0.10),
     servr (>= 0.15)
 Suggests:
-  testit,
-  shiny,
-  miniUI,
-  stringr,
-  rstudioapi,
-  tools,
-  processx,
-  later
+    testit,
+    shiny,
+    miniUI,
+    stringr,
+    rstudioapi,
+    tools,
+    processx,
+    later,
+    whoami
 LazyData: true
 URL: https://github.com/rstudio/blogdown
 BugReports: https://github.com/rstudio/blogdown/issues
 SystemRequirements: Hugo (<https://gohugo.io>) and Pandoc (<https://pandoc.org>)
-RoxygenNote: 7.0.0
+RoxygenNote: 7.0.2
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,18 +32,18 @@ Imports:
     xfun (>= 0.10),
     servr (>= 0.15)
 Suggests:
-    testit,
-    shiny,
-    miniUI,
-    stringr,
-    rstudioapi,
-    tools,
-    processx,
-    later,
-    whoami
+  testit,
+  shiny,
+  miniUI,
+  stringr,
+  rstudioapi,
+  tools,
+  processx,
+  later,
+  whoami
 LazyData: true
 URL: https://github.com/rstudio/blogdown
 BugReports: https://github.com/rstudio/blogdown/issues
 SystemRequirements: Hugo (<https://gohugo.io>) and Pandoc (<https://pandoc.org>)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.0.0
 Encoding: UTF-8

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # CHANGES IN blogdown VERSION 0.18
 
+## NEW FEATURES
 
+- The "New Post" addin in RStudio uses the **whoami** package (if installed) to figure out the author name, in addition to using the global option `getOption('blogdown.author')`. The "Subdirectory" field is now a select input instead of a text input, so you can choose one item from a full list of subdirectories instead of manually typing the directory path (thanks, @maelle @gadenbuie, #432).
 
 # CHANGES IN blogdown VERSION 0.17
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -630,3 +630,34 @@ tweak_hugo_env = function() {
     envir = parent.frame()
   )
 }
+
+get_author <- function() {
+  option1 <- getOption('blogdown.author', '')
+
+  if (option1 != "") {
+    return(option1)
+  }
+
+  if (requireNamespace("whoami")) {
+    whoami::fullname(fallback = "")
+  }
+
+}
+
+get_dir <- function() {
+  option1 <- getOption('blogdown.subdir', '')
+
+  if (option1 != "") {
+    return(option1)
+  }
+
+  option2 <- list.dirs(file.path(site_root(), "content"),
+                       full.names = FALSE,
+                       recursive = FALSE)
+
+  if (length(option2) == 0) {
+    return(post)
+  } else {
+    return(option2)
+  }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -648,5 +648,5 @@ get_subdirs = function() {
     dirs = dirs[substr(dirs, 1, nchar(d)) != d]
   }
 
-  c(getOption('blogdown.subdir', ''), dirs)
+  dirs
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -639,7 +639,9 @@ get_author <- function() {
   }
 
   if (requireNamespace("whoami")) {
-    whoami::fullname(fallback = "")
+    return(whoami::fullname(fallback = ""))
+  } else {
+    return("")
   }
 
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -648,5 +648,5 @@ get_subdirs = function() {
     dirs = dirs[substr(dirs, 1, nchar(d)) != d]
   }
 
-  dirs
+  union(dirs, getOption('blogdown.subdir', 'post'))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -653,5 +653,5 @@ get_subdirs <- function() {
                        full.names = FALSE,
                        recursive = FALSE)
 
-  sort(unique(c(option1, option2)))
+  sort(unique(c('', option1, option2)))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -646,20 +646,12 @@ get_author <- function() {
 
 }
 
-get_dir <- function() {
+get_subdirs <- function() {
   option1 <- getOption('blogdown.subdir', '')
-
-  if (option1 != "") {
-    return(option1)
-  }
 
   option2 <- list.dirs(file.path(site_root(), "content"),
                        full.names = FALSE,
                        recursive = FALSE)
 
-  if (length(option2) == 0) {
-    return(post)
-  } else {
-    return(option2)
-  }
+  sort(unique(c(option1, option2)))
 }

--- a/inst/scripts/new_post.R
+++ b/inst/scripts/new_post.R
@@ -18,7 +18,7 @@ xfun::in_dir(blogdown:::site_root(), local({
         shiny::dateInput('date', 'Date', Sys.Date(), width = '98%'),
         shiny::selectizeInput(
           'subdir', 'Subdirectory', blogdown:::get_subdirs(),
-          selected = getOption('blogdown.subdir', NULL),
+          selected = getOption('blogdown.subdir', 'post'),
           width = '98%', multiple = FALSE,
           options = list(create = TRUE, placeholder = '(optional)')
         ),

--- a/inst/scripts/new_post.R
+++ b/inst/scripts/new_post.R
@@ -14,11 +14,11 @@ xfun::in_dir(blogdown:::site_root(), local({
     miniUI::miniPage(miniUI::miniContentPanel(
       txt_input('title', 'Title', placeholder = 'Post Title'),
       shiny::fillRow(
-        txt_input('author', 'Author', getOption('blogdown.author', ''), width = '98%'),
+        txt_input('author', 'Author', blogdown:::get_author(), width = '98%'),
         shiny::dateInput('date', 'Date', Sys.Date(), width = '98%'),
-        txt_input(
-          'subdir', 'Subdirectory', getOption('blogdown.subdir', 'post'),
-          '(optional)', width = '98%'
+        shiny::selectInput(
+          'subdir', 'Subdirectory', blogdown:::get_dir(),
+          width = '98%'
         ),
         height = '70px'
       ),

--- a/inst/scripts/new_post.R
+++ b/inst/scripts/new_post.R
@@ -17,7 +17,8 @@ xfun::in_dir(blogdown:::site_root(), local({
         txt_input('author', 'Author', blogdown:::get_author(), width = '98%'),
         shiny::dateInput('date', 'Date', Sys.Date(), width = '98%'),
         shiny::selectizeInput(
-          'subdir', 'Subdirectory', blogdown:::get_dir(),
+          'subdir', 'Subdirectory', blogdown:::get_subdirs(),
+          selected = getOption('blogdown.subdir', NULL),
           width = '98%', multiple = FALSE, options = list(create = TRUE)
         ),
         height = '70px'

--- a/inst/scripts/new_post.R
+++ b/inst/scripts/new_post.R
@@ -16,9 +16,9 @@ xfun::in_dir(blogdown:::site_root(), local({
       shiny::fillRow(
         txt_input('author', 'Author', blogdown:::get_author(), width = '98%'),
         shiny::dateInput('date', 'Date', Sys.Date(), width = '98%'),
-        shiny::selectInput(
+        shiny::selectizeInput(
           'subdir', 'Subdirectory', blogdown:::get_dir(),
-          width = '98%'
+          width = '98%', multiple = FALSE, options = list(create = TRUE)
         ),
         height = '70px'
       ),

--- a/inst/scripts/new_post.R
+++ b/inst/scripts/new_post.R
@@ -19,7 +19,8 @@ xfun::in_dir(blogdown:::site_root(), local({
         shiny::selectizeInput(
           'subdir', 'Subdirectory', blogdown:::get_subdirs(),
           selected = getOption('blogdown.subdir', NULL),
-          width = '98%', multiple = FALSE, options = list(create = TRUE)
+          width = '98%', multiple = FALSE,
+          options = list(create = TRUE, placeholder = '(optional)')
         ),
         height = '70px'
       ),


### PR DESCRIPTION
I'm proposing two changes to the very cool New Post addin:

* If there's no `blogdown.author` option and [`whoami`](https://github.com/r-lib/whoami#readme) is installed, try to guess the author name using `whoami`.

* The possible subdirectories are the combination of the option `blogdown.subdir` if it exists, '' and existing subdirectories; the selected value is either `blogdown.subdir or the first option; it is possible to create a subdirectory from the addin. (edited after getting feedback from @gadenbuie)

These suggestions might reduce the setup efforts needed to use the addin.

Opening a PR instead of an issue is a bit bold, and I don't assume my PR will be merged, but it was easier to communicate my ideas by implementing them. :slightly_smiling_face: 