### PR TITLE
make new_post() work for authorS

### DIFF
--- a/R/hugo.R
+++ b/R/hugo.R
@@ -337,11 +337,18 @@ new_post = function(
     )
   }
 
-  do.call(modify_yaml, c(list(
-    file, title = title, author = author, date = format(date), slug = slug,
+  arguments <- c(list(
+    file, title = title, date = format(date), slug = slug,
     categories = as.list(categories), tags = as.list(tags)
   ), if (!file.exists('archetypes/default.md')) list(draft = NULL)
-  ))
+  )
+
+    if (getOption("blogdown.plural_authors", FALSE)) {
+      arguments$authors <- as.list(author)
+    } else {
+      arguments$author <- author
+    }
+  do.call(modify_yaml, arguments)
   if (open) open_file(file)
   file
 }


### PR DESCRIPTION
Once again a PR rather than an issue :see_no_evil: 

In rOpenSci website but also R-hub blog, and less selfishly, RStudio education blog apparently (cc @apreshill) the authors are in a YAML field called "authors" that needs to be a list. I'm suggesting editing `new_post()` a bit so that authors of such sites can use the New Post Addin. :slightly_smiling_face: 