### PR TITLE
Use get_config() in check_lang() to avoid problems with capitalization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # CHANGES IN blogdown VERSION 0.19
 
+## BUG FIXES
+
+- The "Language" field in the "New Post" addin in RStudio now shows up regardless of the capitalization of the `defaultContentLanguage` parameter in `config.toml` (thanks @mpaulacaldas, #442).
 
 # CHANGES IN blogdown VERSION 0.18
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -154,8 +154,8 @@ load_config = function() {
 }
 
 # check if the user has configured Multilingual Mode for Hugo in config.toml
-check_lang = function() {
-  load_config()[['DefaultContentLanguage']]
+check_lang = function(config = load_config()) {
+  get_config('DefaultContentLanguage', NULL, config)
 }
 
 check_config = function(config, f) {


### PR DESCRIPTION
As explained in https://github.com/rstudio/blogdown/issues/323#issuecomment-499290941, currently the "Language" field of the "New post" addin will not show up unless the default content language in `config.toml` is set using `DefaultContentLanguage` (first letter capitalized). If a site uses `defaultConentLanguage` (first letter in lower case), the language field will be ignored since `check_lang()` will return `NULL`.

I submit a PR rather than an issue since the fix seems simple enough. Here I use `get_config()` inside `check_lang()` to get the default content language option in a case-insensitive way. I tested on another blogdown project and everything seems to work as expected.