### PR TITLE
Allow build_rmds to use customs 'dir_blog' and 'dir_src' folders.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -63,6 +63,15 @@ dir_rename = function(from, to, clean = FALSE) {
   }
 }
 
+file_rename = function(from, to, clean = FALSE) {
+  if (!file_exists(from)) return()
+  if (clean) unlink(to, recursive = TRUE)
+  dir_create(dirname(to))
+  suppressWarnings(file.rename(from, to)) || {
+    file.copy(from, dirname(to), recursive = TRUE) && unlink(from, recursive = TRUE)
+  }
+}
+
 dirs_rename = function(from, to, ...) {
   n = length(from); if (n == 0) return()
   if (length(to) != n) stop(


### PR DESCRIPTION
This allows to locate your **Rmd** files on a folder `dir_src` (default: ".") and your **blog** in another folder `dir_blog` (default: "content"). This add flexibility for different workflows. In particular, I am using `blogdown` to keep documentation and reproducibility of a project. An example of the structure is as follows:

```
.
├── data
├── docs                # web folder (includes `content`, `public`, 'static', ...)
├── Makefile            # makefile that uses `builds_rms` for each file
├── scripts             # Rmd scripts folder
└── src
```

Using `blogdown:::build_rmds` with parameters `dir_src = "scripts"` and `dir_blog = "docs"`, will generate and move the files as follow:

```
scripts/clean/rainfall.Rmd    --> scripts/clean/rainfall.Rmd
scripts/clean/rainfall.html   --> docs/content/clean/rainfall.html
scripts/clean/rainfall_files  --> docs/static/clean/rainfall_files
scripts/clean/rainfall_cache  --> docs/blogdown/clean/rainfall_cache
```

This is very useful because now I can use `blogdown:::build_rmds` inside a `Makefile` that defines the dependencies between my `Rmd` files and updates only what needs to be updated.

**Note:** Due to way `blogdown:::site_root` is implemented, we nedd to call `blogdown:::opts$set(site_root = file.path(getwd(), "docs"))` before calling `blogdown:::build_rmds` to work with this workflow.

