### PR TITLE
Tell processx to kill also the child process

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: blogdown
 Type: Package
 Title: Create Blogs and Websites with R Markdown
-Version: 0.20.14
+Version: 0.20.15
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Beilei", "Bian", role = "ctb"),

--- a/R/serve.R
+++ b/R/serve.R
@@ -137,7 +137,7 @@ serve_it = function(pdir = publish_dir(), baseurl = site_base_dir()) {
     if (!server$daemon) return(system2(cmd, cmd_args))
 
     pid = if (getOption('blogdown.use.processx', xfun::loadable('processx'))) {
-      proc = processx::process$new(cmd, cmd_args, stderr = '|')
+      proc = processx::process$new(cmd, cmd_args, stderr = '|', cleanup_tree = FALSE)
       proc$get_pid()
     } else {
       bg_process(cmd, cmd_args)


### PR DESCRIPTION
This will fix #484, the last issue regarding killing processes. 

It seems processx has already kill the main process before the function 
in bookdown's `reg.finalizer` is run. Something relating to the order of garbage collection finalizer as processx will clean when garbage collected. 

Setting `clean_tree` to TRUE will insure that the process **and** its child are killed. 

Let's note that following change in https://github.com/rstudio/blogdown/commit/64d5f46ad0e38a9b399661ca1bcd465763a450bf#commitcomment-43062896, when using processx `stop_server()` will throw the warning when called in the `reg.finalizer`. It does not seem to be printed but I have seen the warning when debuggonce 

* Open a blogdown project (with processx activated)
* `debugonce(blogdown::stop_server)`
* Restart the R Session 
* The main process is already killed and running step by step you'll get the warning. 