### PR TITLE
Stop watching and building Rmd if server is stopped

### DIFF
--- a/R/serve.R
+++ b/R/serve.R
@@ -176,8 +176,8 @@ serve_it = function(pdir = publish_dir(), baseurl = site_base_dir()) {
     watch = servr:::watch_dir('.', rmd_pattern)
     unix = .Platform$OS.type == 'unix'
     watch_build = function() {
-      # Stop watching and delaying if server is stopped
-      if (is.null(opts$get("served_dirs")))  return(invisible())
+      # stop watching if stop_server() has cleared served_dirs
+      if (is.null(opts$get('served_dirs'))) return(invisible())
       if (watch()) {
         # temporarily suspend the process because of this Hugo bug (please, can
         # anyone fix it?): https://github.com/gohugoio/hugo/issues/3811


### PR DESCRIPTION
This will fix when the of behavior observed in #481 

I believe we should stop watching for modification and auto building Rmd is server has been stopped by the user, using `server_stop()`

`opts$get("served_dirs")` seems the right option to check. However, that require setting the first value earlier the first time, that is not in `on.exit`. Is it safe to modify this ? Seems like the change does the same as before while using `okay = FALSE`, then `okay = TRUE`

If not, we could also use `opts$get("pids")` which is set to NULL in `stop_server` or another option if necessary. 

Feel free to change if that is not okay 