### PR TITLE
Refresh viewer with some delay and also on knit.on_save

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -153,7 +153,7 @@ build_rmds = function(files) {
     # when serving the site, pause for a moment so Hugo server's auto navigation
     # can navigate to the output page
     if ((length(opts$get('served_dirs')) || isTRUE(opts$get('render_one')))) {
-      Sys.sleep(getOption('blogdown.build_rmds.wait', 2))
+      server_wait()
     }
 
     if (getOption('blogdown.widgetsID', TRUE)) x = clean_widget_html(x)

--- a/R/serve.R
+++ b/R/serve.R
@@ -82,13 +82,7 @@ preview_site = function(..., startup = FALSE) {
     if (init) for (f in initial_files()) open_file(f)
   } else {
     opts$set(knitting = TRUE)
-    # refresh the viewer because hugo's livereload doesn't work on RStudio
-    # Server: https://github.com/rstudio/rstudio/issues/8096 (TODO: check if
-    # it's fixed in the future: https://github.com/gohugoio/hugo/pull/6698)
-    if (is_rstudio_server()) on.exit({
-      Sys.sleep(getOption('blogdown.rstudio_server.refresh_delay', 1L))
-      rstudioapi::executeCommand('viewerRefresh')
-    }, add = TRUE)
+    on.exit(refresh_viewer(), add = TRUE)
   }
   invisible(serve_site(...))
 }
@@ -203,7 +197,7 @@ serve_it = function(pdir = publish_dir(), baseurl = site_base_dir()) {
     watch_build = function() {
       # stop watching if stop_server() has cleared served_dirs
       if (is.null(opts$get('served_dirs'))) return(invisible())
-      if (watch()) try(rebuild(rmd_files))
+      if (watch()) try({rebuild(rmd_files);refresh_viewer()})
       if (getOption('blogdown.knit.on_save', TRUE)) later::later(watch_build, intv)
     }
     watch_build()
@@ -331,4 +325,17 @@ bg_process = function(command, args = character(), timeout = 30) {
     'Failed to run the command in ', timeout, ' seconds (timeout): ',
     paste(shQuote(c(command, args)), collapse = ' ')
   )
+}
+
+
+# refresh the viewer because hugo's livereload doesn't work on RStudio
+# Server: https://github.com/rstudio/rstudio/issues/8096 (TODO: check if
+# it's fixed in the future: https://github.com/gohugoio/hugo/pull/6698)
+refresh_viewer <- function() {
+  if (is_rstudio_server()) {
+    Sys.sleep(getOption('blogdown.rstudio_server.refresh_delay', 1L))
+    rstudioapi::executeCommand('viewerRefresh')
+    invisible(TRUE)
+  }
+  invisible(FALSE)
 }

--- a/R/serve.R
+++ b/R/serve.R
@@ -197,7 +197,7 @@ serve_it = function(pdir = publish_dir(), baseurl = site_base_dir()) {
     watch_build = function() {
       # stop watching if stop_server() has cleared served_dirs
       if (is.null(opts$get('served_dirs'))) return(invisible())
-      if (watch()) try({rebuild(rmd_files);refresh_viewer()})
+      if (watch()) try({rebuild(rmd_files); refresh_viewer()})
       if (getOption('blogdown.knit.on_save', TRUE)) later::later(watch_build, intv)
     }
     watch_build()
@@ -331,11 +331,12 @@ bg_process = function(command, args = character(), timeout = 30) {
 # refresh the viewer because hugo's livereload doesn't work on RStudio
 # Server: https://github.com/rstudio/rstudio/issues/8096 (TODO: check if
 # it's fixed in the future: https://github.com/gohugoio/hugo/pull/6698)
-refresh_viewer <- function() {
-  if (is_rstudio_server()) {
-    Sys.sleep(getOption('blogdown.rstudio_server.refresh_delay', 1L))
-    rstudioapi::executeCommand('viewerRefresh')
-    invisible(TRUE)
-  }
-  invisible(FALSE)
+refresh_viewer = function() {
+  if (!is_rstudio_server()) return()
+  server_wait()
+  rstudioapi::executeCommand('viewerRefresh')
+}
+
+server_wait = function() {
+  Sys.sleep(getOption('blogdown.server.wait', 2))
 }

--- a/R/serve.R
+++ b/R/serve.R
@@ -85,9 +85,10 @@ preview_site = function(..., startup = FALSE) {
     # refresh the viewer because hugo's livereload doesn't work on RStudio
     # Server: https://github.com/rstudio/rstudio/issues/8096 (TODO: check if
     # it's fixed in the future: https://github.com/gohugoio/hugo/pull/6698)
-    if (is_rstudio_server()) on.exit(
-      rstudioapi::executeCommand('viewerRefresh'), add = TRUE
-    )
+    if (is_rstudio_server()) on.exit({
+      Sys.sleep(getOption('blogdown.rstudio_server.refresh_delay', 1L))
+      rstudioapi::executeCommand('viewerRefresh')
+    }, add = TRUE)
   }
   invisible(serve_site(...))
 }


### PR DESCRIPTION
This complement the feature added in https://github.com/rstudio/blogdown/commit/62b953e4de531ddbe6a59856b04358ce0acd1d62 following the addition in rstudio server https://github.com/rstudio/rstudio/issues/8096#issuecomment-713800748

My test shows we need to add a slight delay before refreshing. Added as an option in case someone needs to increase or want to remove the delay.

Also, I believe we should refresh after knitting automatically on save. Otherwise, same issue, the viewer does not reload because `livereload.js` is not working on Rstudio server.