### PR TITLE
Mentioned publishDate workaround for future date

### DIFF
--- a/R/hugo.R
+++ b/R/hugo.R
@@ -442,7 +442,9 @@ new_post = function(
   if (getOption('blogdown.warn.future', TRUE)) {
     if (tryCatch(date > Sys.Date(), error = function(e) FALSE)) warning(
       'The date of the post is in the future: ', date, '. See ',
-      'https://github.com/rstudio/blogdown/issues/377 for consequences. ',
+      'https://github.com/rstudio/blogdown/issues/377 for consequences, ',
+      'and see https://alison.rbind.io/post/2019-03-04-hugo-troubleshooting/#dates ',
+      'for a workaround by distinguishing date and publishDate in YAML header.',
       'To turn off this warning, set options(blogdown.warn.future = FALSE).'
     )
   }

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -444,7 +444,7 @@ new_post = function(
       'The date of the post is in the future: ', date, '. See ',
       'https://github.com/rstudio/blogdown/issues/377 for consequences, ',
       'and see https://alison.rbind.io/post/2019-03-04-hugo-troubleshooting/#dates ',
-      'for a workaround by distinguishing date and publishDate in YAML header.',
+      'for a workaround by distinguishing date and publishDate in YAML header. ',
       'To turn off this warning, set options(blogdown.warn.future = FALSE).'
     )
   }


### PR DESCRIPTION
Hello,

I have suggested expanding the `blogdown.warn.future` warning by mentioning the `publishDate` workaround.

Thanks