### PR TITLE
Remove hugo message at new site creation on windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@
 
 ## BUG FIXES
 
+- `new_site()` does not show anymore Hugo messages on Windows (#532).
+
 - `serve_site()` fails to start the server when the config file contains a `baseURL` value that includes a subpath in it (thanks, @giabaio #254, @ShixiangWang #494).
 
 - `serve_site()` and `hugo_build()` fail to resolve URLs when `relativeURLs` is configured to `true` (thanks, @TianyiShi2001, #506).

--- a/NEWS.md
+++ b/NEWS.md
@@ -42,8 +42,6 @@
 
 ## BUG FIXES
 
-- `new_site()` does not show anymore Hugo messages on Windows (#532).
-
 - `serve_site()` fails to start the server when the config file contains a `baseURL` value that includes a subpath in it (thanks, @giabaio #254, @ShixiangWang #494).
 
 - `serve_site()` and `hugo_build()` fail to resolve URLs when `relativeURLs` is configured to `true` (thanks, @TianyiShi2001, #506).
@@ -57,6 +55,8 @@
 - `install_hugo()` could not install the extended version of Hugo that was downloaded manually, e.g., `blogdown::install_hugo('~/Downloads/hugo_extended_0.78.2_Linux-64bit.tar.gz')` would fail (thanks, Stuart, https://stackoverflow.com/q/64962659/559676).
 
 - `new_post(date = "")` or `new_post(date = NULL)` failed to work. In both cases, it should create a post without the `date` field in the YAML metadata (thanks, Caleb Stevens, https://stackoverflow.com/q/65067164/559676).
+
+- `new_site()` no longer shows Hugo messages on Windows (#532).
 
 ## MINOR CHANGES
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -873,7 +873,8 @@ if (is_windows()) system2 = function(command, args = character(), stdout = '', .
     })
   )
 
-  if ((res <- base::system2(command, args, ...)) == 0) return(invisible(res))
+  if ((res <- base::system2(command, args, stdout = stdout, ...)) == 0)
+    return(invisible(res))
 
   if ((res <- system(cmd)) == 0) {
     options(blogdown.windows.shell = 'system')


### PR DESCRIPTION
In the special `system2()` wrapper on Windows, `stdout` was not passed to `base::system2` whereas `new_site` was correctly calling `hugo_cmd` with `stdout = FALSE`

This will now correctly remove the Congratulation message that Windows users were still seeing. 

Before : 

```r
> new_site(dir = test_dir)
==> Found hugo at "C:\Users\chris\AppData\Roaming/Hugo/0.78.2/hugo.exe" and "C:\Users\chris\scoop\shims\hugo.exe". The former will be used. If you don't need both copies, you may delete/uninstall the latter perhaps with system2("scoop", c("uninstall", "hugo")).
Congratulations! Your new Hugo site is created in C:\Users\chris\AppData\Local\Temp\Rtmp2h4Bgf\file14f069b55ffe.

Just a few more steps and you're ready to go:

1. Download a theme into the same-named folder.
   Choose a theme from https://themes.gohugo.io/ or
   create your own with the "hugo new theme <THEMENAME>" command.
2. Perhaps you want to add some content. You can add single files
   with "hugo new <SECTIONNAME>\<FILENAME>.<FORMAT>".
3. Start the built-in live server via "hugo server".

Visit https://gohugo.io/ for quickstart guide and full documentation.
```

Now we don't get this message.

@yihui this is the quick fix for the issue. However, we now use `processx` or `xfun::bg_process` for Hugo server. Would it be better to also use this for `hugo_cmd()` ? Or is it a different purpose ? 



