### PR TITLE
remove_hugo prompts when used interactively 

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -301,7 +301,7 @@ find_hugo = local({
 #' @export
 #' @rdname find_hugo
 remove_hugo = function(version = getOption('blogdown.hugo.version'), force = FALSE) {
-  installed = if (interactive()) {
+  installed = if (interactive() && missing(version)) {
     vers = find_hugo("all")
     default = suppressMessages(find_hugo(version))
     if (length(w <- which(default == vers)) != 0) {

--- a/R/install.R
+++ b/R/install.R
@@ -308,7 +308,10 @@ remove_hugo = function(version = getOption('blogdown.hugo.version'), force = FAL
       names(vers) = ""
       names(vers)[w] = "Used by project"
     }
-    select_choice(vers, "Hugo versions found. Which one to remove ?")
+    title = sprintf("%s Hugo version%s found: ",
+                    n <- length(vers), if (n > 1) "s" else "")
+    footnote = "Which Hugo version would you like to remove?"
+    select_choice(vers, title, footnote)
   } else {
     find_hugo(version)
   }

--- a/R/install.R
+++ b/R/install.R
@@ -302,7 +302,13 @@ find_hugo = local({
 #' @rdname find_hugo
 remove_hugo = function(version = getOption('blogdown.hugo.version'), force = FALSE) {
   installed = if (interactive()) {
-    select_choice(find_hugo("all"), "Hugo versions found. Which one to uninstall ?")
+    vers = find_hugo("all")
+    default = suppressMessages(find_hugo(version))
+    if (length(w <- which(default == vers)) != 0) {
+      names(vers) = ""
+      names(vers)[w] = "Used by project"
+    }
+    select_choice(vers, "Hugo versions found. Which one to uninstall ?")
   } else {
     find_hugo(version)
   }

--- a/R/install.R
+++ b/R/install.R
@@ -305,7 +305,6 @@ remove_hugo = function(version = getOption('blogdown.hugo.version'), force = FAL
     vers = find_hugo("all")
     default = suppressMessages(find_hugo(version))
     if (length(w <- which(default == vers)) != 0) {
-      names(vers) = ""
       names(vers)[w] = "(Used by project)"
     }
     title = sprintf("%s Hugo version%s found. Which Hugo version would you like to remove?",

--- a/R/install.R
+++ b/R/install.R
@@ -236,7 +236,7 @@ find_exec = function(cmd, dir, version = NULL, info = '') {
       uninstall_tip(path2), "."
     )
   }
-  normalizePath(path)
+  xfun::normalize_path(path)
 }
 
 uninstall_tip = function(p) {

--- a/R/install.R
+++ b/R/install.R
@@ -308,7 +308,7 @@ remove_hugo = function(version = getOption('blogdown.hugo.version'), force = FAL
       names(vers) = ""
       names(vers)[w] = "Used by project"
     }
-    select_choice(vers, "Hugo versions found. Which one to uninstall ?")
+    select_choice(vers, "Hugo versions found. Which one to remove ?")
   } else {
     find_hugo(version)
   }

--- a/R/install.R
+++ b/R/install.R
@@ -306,7 +306,7 @@ remove_hugo = function(version = getOption('blogdown.hugo.version'), force = FAL
     default = suppressMessages(find_hugo(version))
     if (length(w <- which(default == vers)) != 0) {
       names(vers) = ""
-      names(vers)[w] = "Used by project"
+      names(vers)[w] = "(Used by project)"
     }
     title = sprintf("%s Hugo version%s found: ",
                     n <- length(vers), if (n > 1) "s" else "")

--- a/R/install.R
+++ b/R/install.R
@@ -308,10 +308,9 @@ remove_hugo = function(version = getOption('blogdown.hugo.version'), force = FAL
       names(vers) = ""
       names(vers)[w] = "(Used by project)"
     }
-    title = sprintf("%s Hugo version%s found: ",
+    title = sprintf("%s Hugo version%s found. Which Hugo version would you like to remove?",
                     n <- length(vers), if (n > 1) "s" else "")
-    footnote = "Which Hugo version would you like to remove?"
-    select_choice(vers, title, footnote)
+    select_choice(vers, title)
   } else {
     find_hugo(version)
   }

--- a/R/install.R
+++ b/R/install.R
@@ -301,7 +301,12 @@ find_hugo = local({
 #' @export
 #' @rdname find_hugo
 remove_hugo = function(version = getOption('blogdown.hugo.version'), force = FALSE) {
-  for (f in find_hugo(version)) {
+  installed = if (interactive()) {
+    select_choice(find_hugo("all"), "Hugo versions found. Which one to uninstall ?")
+  } else {
+    find_hugo(version)
+  }
+  for (f in installed) {
     if (!file_exists(f)) f = Sys.which(f)  # e.g., hugo.exe returned from find_hugo()
     d = dirname(f)
     # the parent folder name must be a version number

--- a/R/install.R
+++ b/R/install.R
@@ -310,7 +310,8 @@ remove_hugo = function(version = getOption('blogdown.hugo.version'), force = FAL
     }
     title = sprintf("%s Hugo version%s found. Which Hugo version would you like to remove?",
                     n <- length(vers), if (n > 1) "s" else "")
-    select_choice(vers, title)
+    res = select_choice(vers, title, multiple = TRUE)
+    gsub("\\s+\\(Used by project\\)$", "", res)
   } else {
     find_hugo(version)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1009,30 +1009,25 @@ yes_no = function(question) {
 
 # Will output like this
 # If choices is named, the name is used as suffix as in example below
-# Title:
-# ---------
-# 1: value name
-# ---------
-# footnote
-# ask
-select_choice <- function(choices, title, footnote, ask) {
-  if (!missing(title)) {
-    cat(title, sep = "\n")
-    cat(hrule(), sep = "\n")
+# --------------------------
+# <Title>
+# --------------------------
+# <ask>
+#
+# 1: <choice value> <choice name>
+#
+# Selection:
+#
+select_choice <- function(choices, title = NULL, ask) {
+  if (missing(ask)) {
+    ask = "Use a number below to select (type 0 to cancel): "
   }
-  index = seq_along(choices)
+  if (!is.null(title)) {
+    title = paste(hrule(), title, hrule(), ask, sep = "\n")
+  }
   if (!is.null(nm <- names(choices))) {
     choices = paste(choices, ifelse(is.na(nm) | nm == '', '', nm))
   }
-  cat(paste(index, choices, sep = ": "), sep = "\n")
-  cat(hrule(), sep = "\n")
-  if (!missing(footnote)) cat(footnote, sep = "\n")
-  if (missing(ask)) {
-    ask = "Use a number above to select (type ESC twice to cancel): "
-  }
-  choice = ""
-  while (!choice %in% as.character(index)) {
-    choice = readline(ask)
-  }
-  choices[as.integer(choice)]
+  choice <- utils::select.list(choices, title = title, graphics = FALSE)
+  if (!nzchar(choice)) stop("Operation Cancelled", call. = FALSE)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1006,34 +1006,3 @@ clean_hugo_cache = function() {
 yes_no = function(question) {
   interactive() && tolower(substr(readline(paste(question, '(y/n) ')), 1, 1)) == 'y'
 }
-
-# Will output like this
-# If choices is named, the name is used as suffix i.e
-# --------------------------
-# <Title>
-# --------------------------
-# <ask>
-#
-# 1: <choice value> <choice name>
-#
-# Selection:
-#
-select_choice <- function(choices, title = NULL, multiple = FALSE) {
-  ask = if (!multiple) {
-    "Use a number below to select (type 0 to cancel): "
-  } else NULL
-  if (!is.null(title)) {
-    title = paste(hrule(), title, hrule(), sep = "\n")
-    if (!multiple) title = paste(title, ask, sep = "\n")
-  }
-  if (!is.null(nm <- names(choices))) {
-    for (j in nm) {
-      if (!is.na(j) && nzchar(j)) choices[j] <- sprintf("%s %s", choices[j], j)
-    }
-  }
-  choice = utils::select.list(choices, title = title,
-                               multiple = multiple, graphics = FALSE)
-  if (length(choice) == 1 && !nzchar(choice))
-    stop("Operation Cancelled", call. = FALSE)
-  choice
-}

--- a/R/utils.R
+++ b/R/utils.R
@@ -1007,7 +1007,8 @@ yes_no = function(question) {
   interactive() && tolower(substr(readline(paste(question, '(y/n) ')), 1, 1)) == 'y'
 }
 
-
+# if choices is named, the name is used as suffix i.e
+# 1: value (name)
 select_choice <- function(choices, title, message, width = getOption("width")) {
   if (!missing(title)) {
     cat(format(title, width = width), sep = "\n")
@@ -1017,6 +1018,12 @@ select_choice <- function(choices, title, message, width = getOption("width")) {
     message = "Select one choice above (type ESC twice to cancel): "
   }
   index = seq_along(choices)
+  if (!is.null(nm <- names(choices))) {
+    for (j in nm) {
+      if (!is.na(j) && nzchar(j))
+        choices[j] <- sprintf("%s (%s)", choices[j], j)
+    }
+  }
   cat(format(paste(index, choices, sep = ": "), width = width), sep = "\n")
   choice = ""
   while (!choice %in% as.character(index)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1027,7 +1027,9 @@ select_choice <- function(choices, title = NULL, multiple = FALSE) {
     if (!multiple) title = paste(title, ask, sep = "\n")
   }
   if (!is.null(nm <- names(choices))) {
-    choices = paste0(choices, ifelse(is.na(nm) | nm == '', '', c(" ", nm)))
+    for (j in nm) {
+      if (!is.na(j) && nzchar(j)) choices[j] <- sprintf("%s %s", choices[j], j)
+    }
   }
   choice = utils::select.list(choices, title = title,
                                multiple = multiple, graphics = FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1027,7 +1027,7 @@ select_choice <- function(choices, title = NULL, multiple = FALSE) {
     if (!multiple) title = paste(title, ask, sep = "\n")
   }
   if (!is.null(nm <- names(choices))) {
-    choices = paste(choices, ifelse(is.na(nm) | nm == '', '', nm))
+    choices = paste0(choices, ifelse(is.na(nm) | nm == '', '', c(" ", nm)))
   }
   choice = utils::select.list(choices, title = title,
                                multiple = multiple, graphics = FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1007,15 +1007,18 @@ yes_no = function(question) {
   interactive() && tolower(substr(readline(paste(question, '(y/n) ')), 1, 1)) == 'y'
 }
 
-# if choices is named, the name is used as suffix i.e
+# Will output like this
+# If choices is named, the name is used as suffix as in example below
+# Title:
+# ---------
 # 1: value (name)
-select_choice <- function(choices, title, message, width = getOption("width")) {
+# ---------
+# footnote
+# ask
+select_choice <- function(choices, title, footnote, ask, width = getOption("width")) {
   if (!missing(title)) {
     cat(format(title, width = width), sep = "\n")
     cat(hrule(width = width), sep = "\n")
-  }
-  if (missing(message)) {
-    message = "Select one choice above (type ESC twice to cancel): "
   }
   index = seq_along(choices)
   if (!is.null(nm <- names(choices))) {
@@ -1025,9 +1028,14 @@ select_choice <- function(choices, title, message, width = getOption("width")) {
     }
   }
   cat(format(paste(index, choices, sep = ": "), width = width), sep = "\n")
+  cat(hrule(width = width), sep = "\n")
+  if (!missing(footnote)) cat(format(footnote, width = width), sep = "\n")
+  if (missing(ask)) {
+    ask = "Use a number above to select (type ESC twice to cancel): "
+  }
   choice = ""
   while (!choice %in% as.character(index)) {
-    choice = readline(message)
+    choice = readline(ask)
   }
   choices[as.integer(choice)]
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1011,7 +1011,7 @@ yes_no = function(question) {
 # If choices is named, the name is used as suffix as in example below
 # Title:
 # ---------
-# 1: value (name)
+# 1: value name
 # ---------
 # footnote
 # ask
@@ -1022,10 +1022,7 @@ select_choice <- function(choices, title, footnote, ask) {
   }
   index = seq_along(choices)
   if (!is.null(nm <- names(choices))) {
-    for (j in nm) {
-      if (!is.na(j) && nzchar(j))
-        choices[j] <- sprintf("%s (%s)", choices[j], j)
-    }
+    choices = paste(choices, ifelse(is.na(nm) | nm == '', '', nm))
   }
   cat(paste(index, choices, sep = ": "), sep = "\n")
   cat(hrule(), sep = "\n")

--- a/R/utils.R
+++ b/R/utils.R
@@ -1015,10 +1015,10 @@ yes_no = function(question) {
 # ---------
 # footnote
 # ask
-select_choice <- function(choices, title, footnote, ask, width = getOption("width")) {
+select_choice <- function(choices, title, footnote, ask) {
   if (!missing(title)) {
-    cat(format(title, width = width), sep = "\n")
-    cat(hrule(width = width), sep = "\n")
+    cat(title, sep = "\n")
+    cat(hrule(), sep = "\n")
   }
   index = seq_along(choices)
   if (!is.null(nm <- names(choices))) {
@@ -1027,9 +1027,9 @@ select_choice <- function(choices, title, footnote, ask, width = getOption("widt
         choices[j] <- sprintf("%s (%s)", choices[j], j)
     }
   }
-  cat(format(paste(index, choices, sep = ": "), width = width), sep = "\n")
-  cat(hrule(width = width), sep = "\n")
-  if (!missing(footnote)) cat(format(footnote, width = width), sep = "\n")
+  cat(paste(index, choices, sep = ": "), sep = "\n")
+  cat(hrule(), sep = "\n")
+  if (!missing(footnote)) cat(footnote, sep = "\n")
   if (missing(ask)) {
     ask = "Use a number above to select (type ESC twice to cancel): "
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1008,7 +1008,7 @@ yes_no = function(question) {
 }
 
 # Will output like this
-# If choices is named, the name is used as suffix as in example below
+# If choices is named, the name is used as suffix i.e
 # --------------------------
 # <Title>
 # --------------------------
@@ -1018,16 +1018,20 @@ yes_no = function(question) {
 #
 # Selection:
 #
-select_choice <- function(choices, title = NULL, ask) {
-  if (missing(ask)) {
-    ask = "Use a number below to select (type 0 to cancel): "
-  }
+select_choice <- function(choices, title = NULL, multiple = FALSE) {
+  ask = if (!multiple) {
+    "Use a number below to select (type 0 to cancel): "
+  } else NULL
   if (!is.null(title)) {
-    title = paste(hrule(), title, hrule(), ask, sep = "\n")
+    title = paste(hrule(), title, hrule(), sep = "\n")
+    if (!multiple) title = paste(title, ask, sep = "\n")
   }
   if (!is.null(nm <- names(choices))) {
     choices = paste(choices, ifelse(is.na(nm) | nm == '', '', nm))
   }
-  choice <- utils::select.list(choices, title = title, graphics = FALSE)
-  if (!nzchar(choice)) stop("Operation Cancelled", call. = FALSE)
+  choice = utils::select.list(choices, title = title,
+                               multiple = multiple, graphics = FALSE)
+  if (length(choice) == 1 && !nzchar(choice))
+    stop("Operation Cancelled", call. = FALSE)
+  choice
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1006,3 +1006,21 @@ clean_hugo_cache = function() {
 yes_no = function(question) {
   interactive() && tolower(substr(readline(paste(question, '(y/n) ')), 1, 1)) == 'y'
 }
+
+
+select_choice <- function(choices, title, message, width = getOption("width")) {
+  if (!missing(title)) {
+    cat(format(title, width = width), sep = "\n")
+    cat(hrule(width = width), sep = "\n")
+  }
+  if (missing(message)) {
+    message = "Select one choice above (type ESC twice to cancel): "
+  }
+  index = seq_along(choices)
+  cat(format(paste(index, choices, sep = ": "), width = width), sep = "\n")
+  choice = ""
+  while (!choice %in% as.character(index)) {
+    choice = readline(message)
+  }
+  choices[as.integer(choice)]
+}

--- a/man/find_hugo.Rd
+++ b/man/find_hugo.Rd
@@ -12,7 +12,10 @@ remove_hugo(version = getOption("blogdown.hugo.version"), force = FALSE)
 \arguments{
 \item{version}{The expected version number, e.g., \code{'0.25.1'}. If
 \code{NULL}, it will try to find/remove the maximum possible version. If
-\code{'all'}, find/remove all possible versions.}
+\code{'all'}, find/remove all possible versions. In an interactive R
+session when \code{version} is not provided), \code{remove_hugo()} will
+list all installed versions of Hugo, and you can select which versions to
+remove.}
 
 \item{force}{By default, \code{remove_hugo()} only removes Hugo installed via
 \code{\link{install_hugo}()}. For \code{force = TRUE}, it will try to


### PR DESCRIPTION
This PR contains a suggestion to use a prompt menu to select which Hugo version remove when the function is used interactively. 

This looks like 
```r
> remove_hugo()
Hugo versions found. Which one to remove ?                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------
1: C:/Users/chris/AppData/Roaming/Hugo/0.76.5/hugo.exe                                                                                     
2: C:/Users/chris/AppData/Roaming/Hugo/0.78.2/hugo.exe (Used by project)                                                                   
3: C:/Users/chris/scoop/shims/hugo.exe                                                                                                     
Select one choice above (type ESC twice to cancel): 
```

This uses a new helper call `select_choice` that powers this choice menu. 

About the helper
* `select_choice(choices, title, message, width = getOption("width"))`
* For now, it allow to choose only one choice only. We could improve by allowing multiple choices to be selected
* There is a mechanism to add a suffix in the choices by using the name in the vector if it exists. Result will be `index: value (name)` as seen above

About `remove_hugo` changes
* If `interactive()` it will query for all hugo version
* It will also look for the version used by the project (by option or default one) to precise it in the prompt 
* It will prompt user for which version to remove

What do you think of this feature ? 

If this is interesting I may refactor a bit and add tests

/cc @yihui @apreshill 