### PR TITLE
Update sample date

### DIFF
--- a/R/hugo.R
+++ b/R/hugo.R
@@ -166,7 +166,7 @@ new_site = function(
   if (sample) {
     d = file.path('content', 'blog')
     if (!dir_exists(d)) d = file.path('content', 'post')
-    f1 = pkg_file('resources', '2020-12-20-r-rmarkdown.Rmd')
+    f1 = pkg_file('resources', '2020-12-01-r-rmarkdown.Rmd')
     if (use_bundle()) d = file.path(d, basename(xfun::sans_ext(f1)))
     dir_create(d)
     f2 = file.path(d, if (use_bundle()) 'index.Rmd' else basename(f1))

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -166,7 +166,7 @@ new_site = function(
   if (sample) {
     d = file.path('content', 'blog')
     if (!dir_exists(d)) d = file.path('content', 'post')
-    f1 = pkg_file('resources', '2015-07-23-r-rmarkdown.Rmd')
+    f1 = pkg_file('resources', '2020-12-20-r-rmarkdown.Rmd')
     if (use_bundle()) d = file.path(d, basename(xfun::sans_ext(f1)))
     dir_create(d)
     f2 = file.path(d, if (use_bundle()) 'index.Rmd' else basename(f1))
@@ -455,7 +455,7 @@ content_file = function(...) file.path(
 #'   date.
 #' @param slug The slug of the post. By default (\code{NULL}), the slug is
 #'   generated from the filename by removing the date and filename extension,
-#'   e.g., if \code{file = 'post/2015-07-23-hi-there.md'}, \code{slug} will be
+#'   e.g., if \code{file = 'post/2020-07-23-hi-there.md'}, \code{slug} will be
 #'   \code{hi-there}. Set \code{slug = ''} if you do not want it.
 #' @param title_case A function to convert the title to title case. If
 #'   \code{TRUE}, the function is \code{tools::\link[tools]{toTitleCase}()}).

--- a/inst/resources/2020-12-01-r-rmarkdown.Rmd
+++ b/inst/resources/2020-12-01-r-rmarkdown.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "Hello R Markdown"
 author: "Frida Gomam"
-date: 2015-07-23T21:13:14-05:00
+date: 2020-12-01T21:13:14-05:00
 categories: ["R"]
 tags: ["R Markdown", "plot", "regression"]
 ---


### PR DESCRIPTION
The sample `.Rmd` file we add to a new site had a 2015 date- I updated to `2020-12-01` to help that post not get lost in the sample posts populated by the theme (with Hugo academic, the sample `.Rmd` post ends up on page 2).