### PR TITLE
Updating markdown comparison table for .rmarkdown

### DIFF
--- a/docs/01-introduction.Rmd
+++ b/docs/01-introduction.Rmd
@@ -194,7 +194,7 @@ Table: (\#tab:md-diff) Differences among the three document formats.
 |Bibliography |yes  |yes        |no   |
 |Task list    |maybe|yes        |yes  |
 |MathJax      |yes  |maybe      |maybe|
-|HTML widgets |yes  |yes        |no   |
+|HTML widgets |yes  |no         |no   |
 
 1. You cannot execute any R code in a plain Markdown document, whereas in an R Markdown document, you can embed R code chunks (```` ```{r} ````). However, you can still embed R code in plain Markdown using the syntax for fenced code blocks ```` ```r ```` (note there are no curly braces `{}`). Such code blocks will not be executed and may be suitable for pure demonstration purposes. Below is an example of an R code chunk in R Markdown:
 

--- a/docs/01-introduction.Rmd
+++ b/docs/01-introduction.Rmd
@@ -194,7 +194,7 @@ Table: (\#tab:md-diff) Differences among the three document formats.
 |Bibliography |yes  |yes        |no   |
 |Task list    |maybe|yes        |yes  |
 |MathJax      |yes  |maybe      |maybe|
-|HTML widgets |yes  |yes         |no   |
+|HTML widgets |yes  |yes        |no   |
 
 1. You cannot execute any R code in a plain Markdown document, whereas in an R Markdown document, you can embed R code chunks (```` ```{r} ````). However, you can still embed R code in plain Markdown using the syntax for fenced code blocks ```` ```r ```` (note there are no curly braces `{}`). Such code blocks will not be executed and may be suitable for pure demonstration purposes. Below is an example of an R code chunk in R Markdown:
 

--- a/docs/01-introduction.Rmd
+++ b/docs/01-introduction.Rmd
@@ -194,7 +194,7 @@ Table: (\#tab:md-diff) Differences among the three document formats.
 |Bibliography |yes  |yes        |no   |
 |Task list    |maybe|yes        |yes  |
 |MathJax      |yes  |maybe      |maybe|
-|HTML widgets |yes  |no         |no   |
+|HTML widgets |yes  |yes         |no   |
 
 1. You cannot execute any R code in a plain Markdown document, whereas in an R Markdown document, you can embed R code chunks (```` ```{r} ````). However, you can still embed R code in plain Markdown using the syntax for fenced code blocks ```` ```r ```` (note there are no curly braces `{}`). Such code blocks will not be executed and may be suitable for pure demonstration purposes. Below is an example of an R code chunk in R Markdown:
 
@@ -249,9 +249,9 @@ If you find it is a pain to have to remember the differences between R Markdown 
 
 In this book, we usually mean `.Rmd` files when we say "R Markdown documents," which are compiled to `.html` by default. However, there is another type of R Markdown document with the filename extension `.Rmarkdown`. Such R Markdown documents are compiled to Markdown documents with the extension `.markdown`, which will be processed by Hugo instead of Pandoc. There are two major limitations of using `.Rmarkdown` compared to `.Rmd`:
 
-- You cannot use Markdown features only supported by Pandoc, such as citations. Math expressions only work if you have installed the **xaringan** package [@R-xaringan] and applied the JavaScript solution mentioned in Section \@ref(javascript).
+- You cannot use Markdown features only supported by Pandoc, such as fenced `Div`s.
 
-- HTML widgets are not supported.
+- Math expressions only work if you apply the JavaScript solution mentioned in Section \@ref(javascript).
 
 The main advantage of using `.Rmarkdown` is that the output files are cleaner because they are Markdown files. It can be easier for you to read the output of your posts without looking at the actual web pages rendered. This can be particularly helpful when reviewing GitHub pull requests. Note that numbered tables, figures, equations, and theorems are also supported. You cannot directly use Markdown syntax in table or figure captions, but you can use text references as a workaround (see **bookdown**'s documentation).
 


### PR DESCRIPTION
Changing Feature indicator for "HTML widgets" from "yes" to "no" for `.Rmarkdown` files in the Markdown Comparison table.

.Rmarkdown's lack of support for html widgets is cited later in the docs, but it was appearing as supported in the comparison table.

From the docs:  
>There are two major limitations of using .Rmarkdown compared to .Rmd:  
>You cannot use Markdown features only supported by Pandoc, such as citations. Math expressions only work if you have installed the xaringan package (Xie 2020e) and applied the JavaScript solution mentioned in Section B.3.  
> HTML widgets are not supported.  

Note: a workaround that `.Rmarkdown` does support is saving an html widget to file and then reintroducing it via an iframe.