### PR TITLE
Open files in check functions only if some Todos were found

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## MINOR CHANGES
 
-- `check_netlify()` and `check_config()` do not open file anymore in the IDE if no todo were found. (#569) 
+- `check_netlify()` and `check_config()` do not open files anymore in the IDE if no TODO items were found in them (#569).
 
 - The internal functions `md5sum_filter()` and `timestamp_filter()` have been removed. They were renamed to `filter_md5sum()` and `filter_timestamp()`, respectively, and exported in **blogdown** 1.0. Please use these exported functions instead if you relied on the internal functions previously.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## MINOR CHANGES
 
+- `check_netlify()` and `check_config()` do not open file anymore in the IDE if no todo were found. (#569) 
+
 - The internal functions `md5sum_filter()` and `timestamp_filter()` have been removed. They were renamed to `filter_md5sum()` and `filter_timestamp()`, respectively, and exported in **blogdown** 1.0. Please use these exported functions instead if you relied on the internal functions previously.
 
 # CHANGES IN blogdown VERSION 1.0

--- a/R/check.R
+++ b/R/check.R
@@ -34,7 +34,6 @@ check_config = function() {
   msg_init('Checking ', f)
   okay = TRUE
 
-
   msg_next('Checking "baseURL" setting for Hugo...')
   base = index_ci(config, 'baseurl')
   if (is_example_url(base)) {

--- a/R/check.R
+++ b/R/check.R
@@ -32,14 +32,17 @@ check_config = function() {
   config = load_config()
   f = find_config()
   msg_init('Checking ', f)
-  open_file(f)
+  okay = TRUE
+
 
   msg_next('Checking "baseURL" setting for Hugo...')
   base = index_ci(config, 'baseurl')
   if (is_example_url(base)) {
     msg_todo('Set "baseURL" to "/" if you do not yet have a domain.')
+    okay = FALSE
   } else if (identical(base, '/')) {
     msg_todo('Update "baseURL" to your actual URL when ready to publish.')
+    okay = FALSE
   } else {
     msg_okay('Found baseURL = "', base, '"; nothing to do here!')
   }
@@ -48,13 +51,16 @@ check_config = function() {
   ignore = c('\\.Rmd$', '\\.Rmarkdown$', '_cache$', '\\.knit\\.md$', '\\.utf8\\.md$')
   if (is.null(s <- config[['ignoreFiles']])) {
     msg_todo('Set "ignoreFiles" to ', xfun::tojson(ignore))
+    okay = FALSE
   } else if (!all(ignore %in% s)) {
     msg_todo(
       'Add these items to the "ignoreFiles" setting: ',
       gsub('^\\[|\\]$', '', xfun::tojson(I(setdiff(ignore, s))))
     )
+    okay = FALSE
   } else if ('_files$' %in% s) {
     msg_todo('Remove "_files$" from "ignoreFiles"')
+    okay = FALSE
   } else {
     msg_okay('"ignoreFiles" looks good - nothing to do here!')
   }
@@ -65,6 +71,7 @@ check_config = function() {
     if (is.null(h) || h == 'goldmark') {
       msg_next("You are using the Markdown renderer 'goldmark'.")
       config_goldmark(f)
+      okay = FALSE
     } else if (!is.null(h)) {
       msg_next("You are using the Markdown renderer '", h, "'.")
       msg_okay('No todos now. If you install a new Hugo version, re-run this check.')
@@ -72,6 +79,7 @@ check_config = function() {
   } else {
     msg_okay('All set!', if (!is.null(s)) ' Found the "unsafe" setting for goldmark.')
   }
+  open_file(f, open = interactive() && !okay)
   msg_done(f)
 }
 
@@ -201,15 +209,17 @@ check_netlify = function() {
     msg_todo(f, ' was not found. Use blogdown::config_netlify() to create file.')
   )
   cfg = find_config()
-  open_file(f)
   x = read_toml(f)
   v = x$context$production$environment$HUGO_VERSION
   v2 = as.character(hugo_version())
   if (is.null(v)) v = x$build$environment$HUGO_VERSION
 
+  okay = TRUE
+
   if (is.null(v)) {
     msg_next('HUGO_VERSION not found in ', f, '.')
     msg_todo('Set HUGO_VERSION = ', v2, ' in [build] context of ', f, '.')
+    okay = FALSE
   } else {
     msg_okay('Found HUGO_VERSION = ', v, ' in [build] context of ', f, '.')
     msg_next('Checking that Netlify & local Hugo versions match...')
@@ -231,6 +241,7 @@ check_netlify = function() {
         'and set options(blogdown.hugo.version = "', v, '") in .Rprofile to pin ',
         'this Hugo version (also remember to restart R).'
       )
+      okay = FALSE
     }
   }
 
@@ -246,11 +257,12 @@ check_netlify = function() {
         '" (', if (p3) "Hugo's default" else c('as set in ', cfg), ').'
       )
       msg_todo('Open ', f, ' and under [build] set publish = "', p2, '".')
+      okay = FALSE
     } else {
       msg_okay('Good to go - blogdown and Netlify are using the same publish directory: ', p2)
     }
   }
-
+  open_file(f, interactive() && !okay)
   msg_done(f)
 }
 


### PR DESCRIPTION
This is an improvement based on a feedback in https://github.com/rstudio/blogdown/issues/564#issuecomment-757459310

Currently, the files `config.toml[yaml]` and `netlify.toml` are opened in the IDE if `interactive()` and even if there is nothing to modify in it. I see why it could be surprising (or even annoying) to have some file opened when nothing is to be done in it.

This PR changes this to open those files only if there is at least one todo found. 

I wasn't sure it was worth it, but we could set the default value base on an option (or an argument) if we want a user to have control on it. Currently I did not do it. 