### PR TITLE
Delete the .github/ folder in the downloaded theme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@
 
 - The `new_post()` function does not work with bundle archetypes (thanks, @maelle, #577).
 
+- `install_theme()` will now remove the `.github/` folder if one exists in the theme repo as it is only useful to the theme developer.
+
 ## MINOR CHANGES
 
 - When clicking the Knit button in RStudio to knit a post, the normal knitting process is shown (such as the progress bar) instead of being suppressed (thanks, @Athanasiamo, #572).

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@
 
 - The `new_post()` function does not work with bundle archetypes (thanks, @maelle, #577).
 
-- `install_theme()` will now remove the `.github/` folder if one exists in the theme repo as it is only useful to the theme developer.
+- `install_theme()` will now remove the `.github/` folder if one exists in the theme repo as it is only useful to the theme developer (#584).
 
 ## MINOR CHANGES
 

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -342,10 +342,8 @@ install_theme = function(
       unlink(file.path(thndir, c('tn.png', 'screenshot.png')))
       del_empty_dir(thndir)
     }
-    # delete the .Rprofile if exists, since it's unlikely to be useful
-    unlink(file.path(zipdir, '.Rprofile'))
-    # delete the .github folder if exists, since it's unlikely to be useful too
-    unlink(file.path(zipdir, '.github'), recursive = TRUE)
+    # delete the .Rprofile and .github folder if they exist, since they are unlikely to be useful
+    unlink(file.path(zipdir, c('.Rprofile', '.github')), recursive = TRUE)
     # check the minimal version of Hugo required by the theme
     if (update_hugo && is_theme) {
       if (!is.null(minver <- read_toml(theme_cfg)[['min_version']])) {

--- a/R/hugo.R
+++ b/R/hugo.R
@@ -344,6 +344,8 @@ install_theme = function(
     }
     # delete the .Rprofile if exists, since it's unlikely to be useful
     unlink(file.path(zipdir, '.Rprofile'))
+    # delete the .github folder if exists, since it's unlikely to be useful too
+    unlink(file.path(zipdir, '.github'), recursive = TRUE)
     # check the minimal version of Hugo required by the theme
     if (update_hugo && is_theme) {
       if (!is.null(minver <- read_toml(theme_cfg)[['min_version']])) {


### PR DESCRIPTION
This folder is only useful for the theme developer for the github repository features. It is not useful for the user.

This was encountered in the academic theme for example https://github.com/wowchemy/starter-academic and was why @apreshill try to avoid using Github action in her theme repo https://github.com/hugo-apero/hugo-apero/
