### PR TITLE
also detect Pandoc's inline raw attributes to determine if Pandoc should be run

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -274,7 +274,7 @@ markdown_format = function() get_option(
 run_pandoc = function(x) {
   !is.null(get_option('blogdown.markdown.format')) ||
     length(grep('^(references|bibliography):($| )', x)) ||
-    length(grep('^[`]{3,}\\{=[[:alnum:]]+}$', x))
+    length(grep('[`]{1,}\\{=[[:alnum:]]+}', x))
 }
 
 # given the content of a .html file: replace content/*_files/figure-html with

--- a/tests/testit/test-render.R
+++ b/tests/testit/test-render.R
@@ -1,0 +1,13 @@
+library(testit)
+
+assert('run_pandoc() find when Pandoc needs to convert', {
+  (run_pandoc(c("nothing special", "requiring render")) %==% FALSE)
+  (run_pandoc(c("```{=html}", "using raw block content", "```")) %==% TRUE)
+  (run_pandoc(c("With inline raw `this works too`{=html}")) %==% TRUE)
+  (run_pandoc(c("Using bib", "references:")) %==% TRUE)
+  (run_pandoc(c("Using bib", "bibliography: test.bib")) %==% TRUE)
+  opts = options(blogdown.markdown.format = "gfm")
+  (run_pandoc(c("nothing special", "but option is set")) %==% TRUE)
+  options(opts)
+})
+


### PR DESCRIPTION
This comes from https://community.rstudio.com/t/changes-to-blogdown-shortcode-open-type-html-and-blogdown-shortcode-close-type-html/93727/4 (thanks @datalorax)
  
This PR change the regex to also detect inline raw content and not just block raw content. 

The issue arises with `blogdown::shortcode_open()` because it will use **htmltools** and the new Pandoc's raw attributes to escape inline content - still because **rmarkdown** set the option to do so by default. 

This simplify the regex instead of adding a new one. Does it sound good ?

This fixes the issue reported in community. 

Also:
* Did not added anything to NEWS because there is still a bullet for `blogdown.markdown.format`
* Added some tests because why not.