### PR TITLE
Build & deploy book with GHA

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -8,7 +8,7 @@ on:
     paths_ignore:
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE'
-      - '.github/bookdown.yaml'
+      - '.github/workflows/bookdown.yaml'
   pull_request:
     branches:
       - main
@@ -16,7 +16,7 @@ on:
     paths_ignore:
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE'
-      - '.github/bookdown.yaml'
+      - '.github/workflows/bookdown.yaml'
 
 name: R-CMD-check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -8,6 +8,7 @@ on:
     paths_ignore:
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE'
+      - '.github/bookdown.yaml'
   pull_request:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
     paths_ignore:
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE'
+      - '.github/bookdown.yaml'
 
 name: R-CMD-check
 

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - main
     paths:
       - 'docs/**'
       - '.github/workflows/bookdown.yaml'

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -1,0 +1,95 @@
+on:
+  push:
+    branches:
+      - build-book-gha
+
+name: Build and deploy book
+
+jobs:
+  build:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KNITR_OPTIONS: "knitr.chunk.tidy=TRUE"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v1
+
+      - name: Install Pandoc
+        uses: r-lib/actions/setup-pandoc@v1
+        with:
+          pandoc-version: '2.11.4'
+
+      - name: Install TinyTeX
+        uses: r-lib/actions/setup-tinytex@v1
+        env:
+          # install full prebuilt version
+          TINYTEX_INSTALLER: TinyTeX
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install OS dependencies
+        run: |
+          brew update
+          brew install --cask xquartz
+          brew install --cask calibre
+
+      - name: Install phamtomJS for webshot
+        run: |
+          remotes::install_cran("webshot")
+          webshot::install_phantomjs()
+        shell: Rscript {0}
+
+      - name: Install R dependencies for bookdown
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+        shell: Rscript {0}
+
+      - name: Install blogdown package
+        run: xfun::install_dir(".")
+        shell: Rscript {0}
+
+      - name: Session info
+        run: |
+          options(width = 100)
+          remotes::install_cran("sessioninfo")
+          pkgs <- installed.packages()[, "Package"]
+          sessioninfo::session_info(pkgs, include_base = TRUE)
+          rmarkdown::find_pandoc()
+        shell: Rscript {0}
+
+      - name: Cache bookdown results
+        uses: actions/cache@v2
+        with:
+          path: docs/_bookdown_files
+          key: bookdown-1-${{ hashFiles('docs/*Rmd') }}
+          restore-keys: bookdown-1-
+
+      - name: Build and Deploy all book
+        if: github.event_name == 'push'
+        env:
+          CONNECT_API_KEY: ${{ secrets.RSC_BOOKDOWN_ORG_TOKEN }}
+          CONTENT_ID: 463
+        run: make -C docs all
+
+      - name: Upload book folder for debug
+        # if: failure()
+        uses: actions/upload-artifact@main
+        with:
+          name: book-dir
+          path: docs

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -91,18 +91,18 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.repo.createCommitStatus({
+            github.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
               sha: context.sha,
-              state: 'success',
-              target_url: ${{ env.URL}},
-              description: 'Book deployed!',
-              context: 'bookdown.org'
+              state: "success",
+              target_url: "${{ env.URL}}",
+              description: "Book deployed!",
+              context: "bookdown.org"
             })
 
       - name: Upload book folder for debug
-        if: failure() || success()
+        if: failure()
         uses: actions/upload-artifact@main
         with:
           name: book-dir

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -48,6 +48,8 @@ jobs:
           brew update --preinstall
           brew install --cask xquartz
           brew install --cask calibre
+          # required for pkgdown install
+          brew install harfbuzz fribidi
 
       - name: Install phamtomJS for webshot
         run: |

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -85,6 +85,22 @@ jobs:
           CONTENT_ID: 463
         run: make -C docs all
 
+      - uses: actions/github-script@v3
+        env:
+          URL: https://bookdown.org/yihui/bookdown
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.repo.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: 'success',
+              target_url: ${{ env.URL}},
+              description: 'Book deployed!',
+              context: 'bookdown.org'
+            })
+
       - name: Upload book folder for debug
         if: failure() || success()
         uses: actions/upload-artifact@main

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - build-book-gha
+      - master
 
 name: Build and deploy book
 

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -88,7 +88,7 @@ jobs:
         run: make -C docs all
 
       - name: Upload book folder for debug
-        # if: failure()
+        if: failure() || sucess()
         uses: actions/upload-artifact@main
         with:
           name: book-dir

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}-${{ hasFiles('docs/index.Rmd') }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}-${{ hashFiles('docs/index.Rmd') }}
           restore-keys: |
             ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}-
             ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -53,13 +53,7 @@ jobs:
           # required for pkgdown install
           brew install harfbuzz fribidi
 
-      - name: Install phamtomJS for webshot
-        run: |
-          remotes::install_cran("webshot")
-          webshot::install_phantomjs()
-        shell: Rscript {0}
-
-      - name: Install R dependencies for bookdown
+      - name: Install R dependencies for blogdown
         run: |
           remotes::install_deps(dependencies = TRUE)
         shell: Rscript {0}

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -2,6 +2,9 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'docs/**'
+      - '.github/workflows/bookdown.yaml'
 
 name: Build and deploy book
 

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -88,7 +88,7 @@ jobs:
         run: make -C docs all
 
       - name: Upload book folder for debug
-        if: failure() || sucess()
+        if: failure() || success()
         uses: actions/upload-artifact@main
         with:
           name: book-dir

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install OS dependencies
         run: |
-          brew update
+          brew update --preinstall
           brew install --cask xquartz
           brew install --cask calibre
 

--- a/.github/workflows/bookdown.yaml
+++ b/.github/workflows/bookdown.yaml
@@ -40,8 +40,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}-${{ hasFiles('docs/index.Rmd') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}-
+            ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
       - name: Install OS dependencies
         run: |

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,8 +1,15 @@
 all:
-	Rscript --quiet _render.R
+	BOOKDOWN_FULL_PDF=false Rscript --quiet _render.R
 
 pdf:
-	Rscript --quiet _render.R "bookdown::pdf_book"
+	Rscript --quiet _render.R "bookdown::pdf_book" &&\
+	mv _book/blogdown.pdf _book/blogdown-full.pdf
+
+pdf2:
+	BOOKDOWN_FULL_PDF=false Rscript --quiet _render.R "bookdown::pdf_book"
 
 gitbook:
 	Rscript --quiet _render.R "bookdown::gitbook"
+
+clean:
+	Rscript --quiet -e "bookdown::clean_book(TRUE)"

--- a/docs/_render.R
+++ b/docs/_render.R
@@ -18,6 +18,26 @@ for (fmt in formats) {
   if (res != 0) stop('Failed to compile the book to ', fmt)
 }
 
-if (length(formats) > 1 && Sys.getenv('USER') == 'yihui') bookdown::publish_book()
+# When several format are rendered, usually when make all is called,
+# then we publish everything to bookdown.org
+# TODO: Uncomment when building works
+# if (length(formats) > 1) {
+#   if (!is.na(Sys.getenv("CI", NA))) {
+#     # On CI connect to server, using API KEY and deploy using appId
+#     rsconnect::addConnectServer('https://bookdown.org', 'bookdown.org')
+#     rsconnect::connectApiUser(
+#       account = 'GHA', server = 'bookdown.org',
+#       apiKey = Sys.getenv('CONNECT_API_KEY')
+#     )
+#     rsconnect::deploySite(
+#       appId = Sys.getenv('CONTENT_ID'),
+#       server = 'bookdown.org',
+#       render = 'none', logLevel = 'verbose',
+#       forceUpdate = TRUE)
+#   } else if (Sys.getenv('USER') == 'yihui') {
+#     # for local deployment when rsconnect/ is available
+#     bookdown::publish_book('blogdown', server = 'bookdown.org', render = 'none')
+#   }
+# }
 
 setwd(owd)

--- a/docs/_render.R
+++ b/docs/_render.R
@@ -20,24 +20,23 @@ for (fmt in formats) {
 
 # When several format are rendered, usually when make all is called,
 # then we publish everything to bookdown.org
-# TODO: Uncomment when building works
-# if (length(formats) > 1) {
-#   if (!is.na(Sys.getenv("CI", NA))) {
-#     # On CI connect to server, using API KEY and deploy using appId
-#     rsconnect::addConnectServer('https://bookdown.org', 'bookdown.org')
-#     rsconnect::connectApiUser(
-#       account = 'GHA', server = 'bookdown.org',
-#       apiKey = Sys.getenv('CONNECT_API_KEY')
-#     )
-#     rsconnect::deploySite(
-#       appId = Sys.getenv('CONTENT_ID'),
-#       server = 'bookdown.org',
-#       render = 'none', logLevel = 'verbose',
-#       forceUpdate = TRUE)
-#   } else if (Sys.getenv('USER') == 'yihui') {
-#     # for local deployment when rsconnect/ is available
-#     bookdown::publish_book('blogdown', server = 'bookdown.org', render = 'none')
-#   }
-# }
+if (length(formats) > 1) {
+  if (!is.na(Sys.getenv("CI", NA))) {
+    # On CI connect to server, using API KEY and deploy using appId
+    rsconnect::addConnectServer('https://bookdown.org', 'bookdown.org')
+    rsconnect::connectApiUser(
+      account = 'GHA', server = 'bookdown.org',
+      apiKey = Sys.getenv('CONNECT_API_KEY')
+    )
+    rsconnect::deploySite(
+      appId = Sys.getenv('CONTENT_ID'),
+      server = 'bookdown.org',
+      render = 'none', logLevel = 'verbose',
+      forceUpdate = TRUE)
+  } else if (Sys.getenv('USER') == 'yihui') {
+    # for local deployment when rsconnect/ is available
+    bookdown::publish_book('blogdown', server = 'bookdown.org', render = 'none')
+  }
+}
 
 setwd(owd)

--- a/docs/_render.R
+++ b/docs/_render.R
@@ -22,6 +22,7 @@ for (fmt in formats) {
 # then we publish everything to bookdown.org
 if (length(formats) > 1) {
   if (!is.na(Sys.getenv("CI", NA))) {
+    xfun::pkg_load2("rsconnect")
     # On CI connect to server, using API KEY and deploy using appId
     rsconnect::addConnectServer('https://bookdown.org', 'bookdown.org')
     rsconnect::connectApiUser(

--- a/docs/index.Rmd
+++ b/docs/index.Rmd
@@ -18,13 +18,13 @@ github-repo: rstudio/blogdown
 cover-image: images/cover.png
 ---
 
-```{r setup, include=FALSE}
+```{r setup, include=FALSE, tidy = FALSE}
 options(
   htmltools.dir.version = FALSE, formatR.indent = 2,
   width = 55, digits = 4, warnPartialMatchAttr = FALSE, warnPartialMatchDollar = FALSE
 )
 
-lapply(c("formatR"), function(pkg) {
+lapply(c('formatR', 'htmlwidgets', 'webshot', 'servr', 'xaringan', 'animation',  'processx', 'later', 'widgetframe', 'pkgdown'), function(pkg) {
   if (system.file(package = pkg) == '') install.packages(pkg)
 })
 ```

--- a/docs/index.Rmd
+++ b/docs/index.Rmd
@@ -24,7 +24,7 @@ options(
   width = 55, digits = 4, warnPartialMatchAttr = FALSE, warnPartialMatchDollar = FALSE
 )
 
-lapply(c(), function(pkg) {
+lapply(c("formatR"), function(pkg) {
   if (system.file(package = pkg) == '') install.packages(pkg)
 })
 ```

--- a/docs/index.Rmd
+++ b/docs/index.Rmd
@@ -24,8 +24,8 @@ options(
   width = 55, digits = 4, warnPartialMatchAttr = FALSE, warnPartialMatchDollar = FALSE
 )
 
-# install missing packages
-lapply(c('formatR', 'htmlwidgets', 'webshot', 'servr', 'xaringan', 'animation',  'processx', 'later', 'widgetframe', 'pkgdown'), function(pkg) {
+# install missing packages, some of theme are for citations references
+lapply(c('formatR', 'htmlwidgets', 'servr', 'animation',  'processx', 'widgetframe', 'pkgdown'), function(pkg) {
   if (system.file(package = pkg) == '') install.packages(pkg)
 })
 

--- a/docs/index.Rmd
+++ b/docs/index.Rmd
@@ -24,8 +24,20 @@ options(
   width = 55, digits = 4, warnPartialMatchAttr = FALSE, warnPartialMatchDollar = FALSE
 )
 
+# install missing packages
 lapply(c('formatR', 'htmlwidgets', 'webshot', 'servr', 'xaringan', 'animation',  'processx', 'later', 'widgetframe', 'pkgdown'), function(pkg) {
   if (system.file(package = pkg) == '') install.packages(pkg)
+})
+
+# latex post process
+options(bookdown.post.latex = function(x) {
+
+  # only build a skeleton for the online version
+  if (Sys.getenv('BOOKDOWN_FULL_PDF', '') == 'false') return(bookdown:::strip_latex_body(
+    x, '\nThis PDF is only a skeleton. Please either read the free online HTML version, or purchase a hard-copy of this book.\n'
+    ))
+
+  x
 })
 ```
 


### PR DESCRIPTION
This PR aims to have the book build and publish on GHA. This use the same logic than for the bookdown books:

- The build and publish logic is in `_render.R`
- Makefile is used to run this R file. 
- Book is published on all formats on bookdown.org
- Trigger will be on push to master when a change in `docs/`