### PR TITLE
Allow to use `list_rmds()` as a filter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,8 @@
 
 ## BUG FIXES
 
+- When serving the site with `blogdown::serve_site()` with `'blogdown.knit.on_save'` option being `TRUE`, Rmd files in `renv/` or `packrat/` folder are now correctly ignored and not rebuilt (#593).
+
 - For `.Rmarkdown` posts, the Markdown extension `tex_math_dollars` should not be used when post-processing the `.markdown` output file with Pandoc < v2.10.1 (thanks, @lz100, #578).
 
 - The `new_post()` function does not work with bundle archetypes (thanks, @maelle, #577).

--- a/R/render.R
+++ b/R/render.R
@@ -101,13 +101,15 @@ build_method = function() {
   match.arg(get_option('blogdown.method', methods), methods)
 }
 
-list_rmds = function(dir = content_file(), check = FALSE, pattern = rmd_pattern) {
-  files = list_files(dir, pattern)
+# list and/or filter Rmd file to build
+list_rmds = function(dir = content_file(), check = FALSE,
+                     pattern = rmd_pattern, files = NULL) {
+  if (is.null(files)) files = list_files(dir, pattern)
   # exclude Rmd that starts with _ (preserve these names for, e.g., child docs)
   # but include _index.Rmd/.md
   files = files[!grepl('^_', basename(files)) | grepl('^_index[.]', basename(files))]
   # exclude Rmd within packrat / renv library
-  files = files[!grepl('/(?:packrat|renv)/', files)]
+  files = files[!grepl('(?:^|/)(?:packrat|renv)/', files)]
   # do not allow special characters in filenames so dependency names are more
   # predictable, e.g. foo_files/
   if (check) bookdown:::check_special_chars(files)

--- a/R/render.R
+++ b/R/render.R
@@ -109,7 +109,7 @@ list_rmds = function(dir = content_file(), check = FALSE,
   # but include _index.Rmd/.md
   files = files[!grepl('^_', basename(files)) | grepl('^_index[.]', basename(files))]
   # exclude Rmd within packrat / renv library
-  files = files[!grepl('(?:^|/)(?:packrat|renv)/', files)]
+  files = files[!grepl('/(?:packrat|renv)/', files)]
   # do not allow special characters in filenames so dependency names are more
   # predictable, e.g. foo_files/
   if (check) bookdown:::check_special_chars(files)

--- a/R/render.R
+++ b/R/render.R
@@ -102,8 +102,9 @@ build_method = function() {
 }
 
 # list and/or filter Rmd file to build
-list_rmds = function(dir = content_file(), check = FALSE,
-                     pattern = rmd_pattern, files = NULL) {
+list_rmds = function(
+  dir = content_file(), check = FALSE, pattern = rmd_pattern, files = NULL
+) {
   if (is.null(files)) files = list_files(dir, pattern)
   # exclude Rmd that starts with _ (preserve these names for, e.g., child docs)
   # but include _index.Rmd/.md

--- a/R/serve.R
+++ b/R/serve.R
@@ -211,7 +211,7 @@ serve_it = function(pdir = publish_dir(), baseurl = site_base_dir()) {
     rebuild(rmd_files <- filter_newfile(list_rmds()))
 
     watch = servr:::watch_dir('.', rmd_pattern, handler = function(files) {
-      rmd_files <<- files
+      rmd_files <<- list_rmds(files = files)
     })
     watch_build = function() {
       # stop watching if stop_server() has cleared served_dirs

--- a/tests/testit/test-list.R
+++ b/tests/testit/test-list.R
@@ -6,9 +6,11 @@ assert('list_rmds() ignores thing in renv / packrat folder', {
   dir.create(dir, recursive = TRUE)
 
   dir.create(file.path(dir, 'renv'))
-  file.create(file.path(dir, 'renv/ignore.Rmd'))
+  file.create(rmd_renv <- file.path(dir, 'renv/ignore.Rmd'))
 
   rmd = list_rmds(dir)
+  (rmd %==% character())
+  rmd = list_rmds(files = rmd_renv)
   (rmd %==% character())
 
   unlink(dir, recursive = TRUE)


### PR DESCRIPTION
This fixes #592 

* `list_rmds` can now be used as a filter 
* It is used in `servr:::watch_dir` handler to set the rmd to be built 
