### PR TITLE
Check if RStudio is running before calling its API.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,8 @@
 
 - Plots generated from R code chunks in posts cannot be previewed on RStudio Server (thanks, @cderv [@datawookie](https://datawookie.dev/blog/2021/02/setting-up-postref-shortcode-for-remote-blog/) #587).
 
+- The error "RStudio is not running" should be suppressed when building the site in a non-interactive R session (thanks, @kcarnold, #596).
+
 - The theme `gcushen/hugo-academic` is now correctly automatically redirected to `wowchemy/starter-academic` with correct default git branch when installing with `new_site()` or `install_theme()`.
 
 ## MINOR CHANGES

--- a/R/site.R
+++ b/R/site.R
@@ -26,9 +26,9 @@ blogdown_site = function(input, ...) {
         build_site(TRUE, run_hugo = FALSE, build_rmd = input_file)
       # run serve_site() to preview the site if the server has not been started
       if (get_option('blogdown.knit.serve_site', Sys.getenv('BLOGDOWN_SERVING_DIR') == '')) {
-        if (interactive()) preview_site()
-        else if (rstudioapi::isAvailable()) tryCatch(
-          rstudioapi::sendToConsole('blogdown:::preview_site()', echo = FALSE)
+        if (interactive()) preview_site() else tryCatch(
+          rstudioapi::sendToConsole('blogdown:::preview_site()', echo = FALSE),
+          error = function(e) {}
         )
       }
     }) else {

--- a/R/site.R
+++ b/R/site.R
@@ -26,7 +26,8 @@ blogdown_site = function(input, ...) {
         build_site(TRUE, run_hugo = FALSE, build_rmd = input_file)
       # run serve_site() to preview the site if the server has not been started
       if (get_option('blogdown.knit.serve_site', Sys.getenv('BLOGDOWN_SERVING_DIR') == '')) {
-        if (interactive()) preview_site() else tryCatch(
+        if (interactive()) preview_site()
+        else if (rstudioapi::isAvailable()) tryCatch(
           rstudioapi::sendToConsole('blogdown:::preview_site()', echo = FALSE)
         )
       }


### PR DESCRIPTION
I have a Makefile to build pages in my blogdown site. I was getting an error "RStudio is not running" in some circumstances.

This patch checks if `rstudioapi` is available before calling it. I'm confused why this `else` condition is even there; under what circumstance is `interactive()` false while running within RStudio? The Knit button?

