### PR TITLE
clean_duplicates() is now aware of blogdown rendering method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: blogdown
 Type: Package
 Title: Create Blogs and Websites with R Markdown
-Version: 1.3.1
+Version: 1.3.2
 Authors@R: c(
     person("Yihui", "Xie", role = c("aut", "cre"), email = "xie@yihui.name", comment = c(ORCID = "0000-0003-0645-5666")),
     person("Christophe", "Dervieux", role = "aut", email = "cderv@rstudio.com", comment = c(ORCID = "0000-0003-4474-2498")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # CHANGES IN blogdown VERSION 1.4
 
+- `clean_duplicates()` now correctly deletes duplicated `.html` file instead of `.md` when `blogdown.method` option is set to `markdown` (thanks, @apreshill, #628).
 
 # CHANGES IN blogdown VERSION 1.3
 

--- a/R/check.R
+++ b/R/check.R
@@ -468,9 +468,13 @@ clean_duplicates = function(preview = TRUE) in_root({
   x = list_duplicates()
   x1 = with_ext(x, 'Rmd');       i1 = file_exists(x1)
   x2 = with_ext(x, 'Rmarkdown'); i2 = file_exists(x2)
-  # if .Rmd exists, delete .md; if .Rmd does not exist or .Rmarkdown exists,
-  # delete .html
-  x = c(with_ext(x[i1], 'md'), x[i2 | !i1])
+  x = c(
+    # if .Rmd exists using 'html' method then delete '.md'
+    # if .Rmd exists using using 'markdown' method, deletes html
+    with_ext(x[i1], if (build_method() == 'markdown') 'html' else 'md'),
+    # if .Rmd does not exist or .Rmarkdown exists, delete html
+    x[i2 | !i1]
+  )
   x = x[file_exists(x)]
   if (length(x)) {
     if (preview) msg_cat(


### PR DESCRIPTION
This should fix #628 

@apreshill could you test this is working for you as expected ? 

Code with `x1`, `x2`, `i1`, `i2` is not always easy to understand at reading but I think I got it right. 

In case of duplicates  (two files with same name and extension `.md` AND `.html`), if an associated `.Rmd` files exists then, if `blogdown.method` is `markdown`, `.html` is deleted, otherwise ( method html) `.md`. 

If this works, I'll add the new bullet. 

Unit tests are not so easy with blogdown project - they often require a dummy project as in this case. 😟 