### PR TITLE
Add option blogdown.filename.date_format for filename date format

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -612,7 +612,8 @@ post_filename = function(title, subdir, ext, date, lang = '', bundle = use_bundl
 
 date_filename = function(path, date, replace = FALSE) {
   if (length(date) == 0 || is.na(date)) date = ''
-  date = format(date)
+  date_format = get_option('blogdown.filename.date_format', '%Y-%m-%d')
+  date = format(date, date_format)
   if (date == '') return(path)
   # FIXME: this \\d{4} will be problematic in about 8000 years
   m = grepl(r <- '(^|[\\/])\\d{4}-\\d{2}-\\d{2}-', path)


### PR DESCRIPTION
Hi!

I have quite a few posts in my blog and I recently re-organised them so that they are divided up into directories by year. This makes it a lot easier to find a specific post.

However, I noticed that when using the _New Post_ addin the posts are not being inserted into the appropriate directory. This is not surprising!

This small contribution adds a package option, `blogdown.filename.date_format`, which can be used to customise the path of new file names. By default the value is `'%Y-%m-%d'`, which gives the current behaviour. For the case of my directory structure, I set

```
options(blogdown.filename.date_format = "%Y/%Y-%m-%d")
```

and my new filenames have an additional component for the year.

**For example:**

Old filename: `blog/2021-09-25-test-post/index.Rmd`
New filename: `blog/2021/2021-09-25-test-post/index.Rmd`

Best regards, Andrew.