### PR TITLE
`serve_site()`: Add support for `bundle exec jekyll`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Added a `repo` argument to `new_site()` so that users can provide a Git repo URL, and `new_site()` will pull the repo into the new site. It saves a bit effort of running `git init` and `git remote add origin` manually. This argument is also supported in the RStudio new project wizard for creating **blogdown** sites.
 
+- For Jekyll sites, a new global option can be used to determine whether to run `jekyll` directly or use the `bundler` gem to run `jekyll` (i.e., `bundle exec jekyll`). If you prefer the latter way, you may set `options(blogdown.jekyll.bundler = TRUE)` before running `blogdown::serve_site()` (thanks, @pat-s, #695).
+
 # CHANGES IN blogdown VERSION 1.9
 
 ## NEW FEATURES

--- a/R/serve.R
+++ b/R/serve.R
@@ -135,6 +135,11 @@ serve_it = function(pdir = publish_dir(), baseurl = site_base_dir()) {
     # run a function (if configured) before starting the server
     if (is.function(serve_first <- getOption('blogdown.server.first'))) serve_first()
 
+    # call jekyll directly or use the bundler gem
+    if (g == 'jekyll' && getOption('blogdown.jekyll.bundler', FALSE)) {
+      cmd = 'bundle'; cmd_args = c('exec', g, cmd_args)
+    }
+
     # if requested not to demonize the server, run it in the foreground process,
     # which will block the R session
     if (!server$daemon) return(system2(cmd, cmd_args))

--- a/R/serve.R
+++ b/R/serve.R
@@ -46,10 +46,6 @@ serve_site = function(..., .site_dir = NULL) {
       baseurl = get_config2('baseurl', ''),
       pdir = get_config2('destination', '_site')
     ),
-    bundler_jekyll = serve_it(
-      baseurl = get_config2('baseurl', ''),
-      pdir = get_config2('destination', '_site')
-    ),
     hexo = serve_it(
       baseurl = get_config2('root', ''),
       pdir = get_config2('public_dir', 'public')
@@ -120,25 +116,13 @@ serve_it = function(pdir = publish_dir(), baseurl = site_base_dir()) {
     })
 
     # launch the hugo/jekyll/hexo server
-    cmd = if (g == 'hugo') find_hugo() else if (g == "bundler_jekyll") "bundler exec jekyll" else g
+    cmd = if (g == 'hugo') find_hugo() else g
     host = server$host; port = server$port; intv = server$interval
     if (!servr:::port_available(port, host)) stop(
       'The port ', port, ' at ', host, ' is unavailable', call. = FALSE
     )
-    if (g == "bundler_jekyll") {
-      args_fun = match.fun('jekyll_server_args')
-    }
-    else {
-      args_fun = match.fun(paste0(g, '_server_args'))
-    }
-    if (g == "bundler_jekyll") {
-      cmd_args = c("exec", "jekyll", args_fun(host, port))
-    } else {
-      cmd_args = args_fun(host, port)
-    }
-    if (g == "bundler_jekyll") {
-      cmd = "bundle"
-    }
+    args_fun = match.fun(paste0(g, '_server_args'))
+    cmd_args = args_fun(host, port)
     if (g == 'hugo') {
       # RStudio Server uses a proxy like http://localhost:8787/p/56a946ed/ for
       # http://localhost:4321, so we must use relativeURLs = TRUE:
@@ -196,9 +180,6 @@ serve_it = function(pdir = publish_dir(), baseurl = site_base_dir()) {
     # server is correctly started so we record the directory served
     opts$append(served_dirs = root)
     Sys.setenv(BLOGDOWN_SERVING_DIR = root)
-    if (g == "bundler_jekyll") {
-      g = "jekyll"
-    }
     message(
       'Launched the ', g, ' server in the background (process ID: ', pid, '). ',
       'To stop it, call blogdown::stop_server() or restart the R session.'

--- a/R/serve.R
+++ b/R/serve.R
@@ -46,6 +46,10 @@ serve_site = function(..., .site_dir = NULL) {
       baseurl = get_config2('baseurl', ''),
       pdir = get_config2('destination', '_site')
     ),
+    bundler_jekyll = serve_it(
+      baseurl = get_config2('baseurl', ''),
+      pdir = get_config2('destination', '_site')
+    ),
     hexo = serve_it(
       baseurl = get_config2('root', ''),
       pdir = get_config2('public_dir', 'public')
@@ -116,13 +120,25 @@ serve_it = function(pdir = publish_dir(), baseurl = site_base_dir()) {
     })
 
     # launch the hugo/jekyll/hexo server
-    cmd = if (g == 'hugo') find_hugo() else g
+    cmd = if (g == 'hugo') find_hugo() else if (g == "bundler_jekyll") "bundler exec jekyll" else g
     host = server$host; port = server$port; intv = server$interval
     if (!servr:::port_available(port, host)) stop(
       'The port ', port, ' at ', host, ' is unavailable', call. = FALSE
     )
-    args_fun = match.fun(paste0(g, '_server_args'))
-    cmd_args = args_fun(host, port)
+    if (g == "bundler_jekyll") {
+      args_fun = match.fun('jekyll_server_args')
+    }
+    else {
+      args_fun = match.fun(paste0(g, '_server_args'))
+    }
+    if (g == "bundler_jekyll") {
+      cmd_args = c("exec", "jekyll", args_fun(host, port))
+    } else {
+      cmd_args = args_fun(host, port)
+    }
+    if (g == "bundler_jekyll") {
+      cmd = "bundle"
+    }
     if (g == 'hugo') {
       # RStudio Server uses a proxy like http://localhost:8787/p/56a946ed/ for
       # http://localhost:4321, so we must use relativeURLs = TRUE:
@@ -180,6 +196,9 @@ serve_it = function(pdir = publish_dir(), baseurl = site_base_dir()) {
     # server is correctly started so we record the directory served
     opts$append(served_dirs = root)
     Sys.setenv(BLOGDOWN_SERVING_DIR = root)
+    if (g == "bundler_jekyll") {
+      g = "jekyll"
+    }
     message(
       'Launched the ', g, ' server in the background (process ID: ', pid, '). ',
       'To stop it, call blogdown::stop_server() or restart the R session.'

--- a/R/utils.R
+++ b/R/utils.R
@@ -276,7 +276,6 @@ config_files = function(which = generator()) {
   all = list(
     hugo = c('config.toml', 'config.yaml'),  # only support TOML and YAML (no JSON)
     jekyll = '_config.yml',
-    bundler_jekyll = '_config.yml',
     hexo = '_config.yml'
   )
   all$hugo = c(all$hugo, file.path('config', '_default', all$hugo))

--- a/R/utils.R
+++ b/R/utils.R
@@ -276,6 +276,7 @@ config_files = function(which = generator()) {
   all = list(
     hugo = c('config.toml', 'config.yaml'),  # only support TOML and YAML (no JSON)
     jekyll = '_config.yml',
+    bundler_jekyll = '_config.yml',
     hexo = '_config.yml'
   )
   all$hugo = c(all$hugo, file.path('config', '_default', all$hugo))


### PR DESCRIPTION
This PR adds support for `bundle exec jekyll` for `serve_site()`. The only change the user needs to do is to set `options(blogdown.generator = "bundler_jekyll")`.

fixes #694 

- The actual command issues is `bundle` which is coming from the `bundler` GEM (note the additional 'r'). 
- Not bound to any naming, feel free to adjust and possible simplify/reduce the ifelse statements
- Tested on a jekyll site which only runs using `bundle exec jekyll`
- Requires `bundle` to be found on the path (`gem install bundler`)