### PR TITLE
small fix in docs/01-introduction.Rmd

### DIFF
--- a/docs/01-introduction.Rmd
+++ b/docs/01-introduction.Rmd
@@ -625,15 +625,12 @@ If you care a lot about the appearance of your website, you will probably spend 
 
 There are now about 400 Hugo themes to choose from. To save you some time, we list a few themes below that match our taste:
 
-- Simple/minimal themes: [XMin,](https://themes.gohugo.io/hugo-xmin/) 
-[Tanka,](https://themes.gohugo.io/hugo-tanka/) 
-[Cupper,](https://themes.gohugo.io/cupper-hugo-theme/) and 
-[ghostwriter.](https://themes.gohugo.io/ghostwriter/)
+- Simple/minimal themes: [XMin,](https://themes.gohugo.io/hugo-xmin/) [Tanka,](https://themes.gohugo.io/hugo-tanka/)
+[Cupper,](https://themes.gohugo.io/cupper-hugo-theme/)
+[simple-a,](https://themes.gohugo.io/simple-a/) and [ghostwriter.](https://themes.gohugo.io/ghostwriter/)
 
-- Sophisticated themes: [Even,](https://themes.gohugo.io/hugo-theme-even/) 
-[Tranquilpeak,](https://themes.gohugo.io/hugo-tranquilpeak-theme/) 
-[Creative portfolio,](https://themes.gohugo.io/hugo-creative-portfolio-theme/) and 
-[Universal.](https://themes.gohugo.io/hugo-universal-theme/)
+- Sophisticated themes: [Even,](https://themes.gohugo.io/hugo-theme-even/) [Tranquilpeak,](https://themes.gohugo.io/hugo-tranquilpeak-theme/)
+[Creative portfolio,](https://themes.gohugo.io/hugo-creative-portfolio-theme/) and [Universal.](https://themes.gohugo.io/hugo-universal-theme/)
 
 - Multimedia content themes: If you are interested in adding multimedia content to your site (such as audio files of a podcast), the [castanet](https://github.com/mattstratton/castanet) theme provides an excellent framework tailored for this application.  An example of a site using **blogdown** with the castanet theme is the [R-Podcast.](https://www.r-podcast.org)
 
@@ -661,7 +658,6 @@ To use a Hugo theme other than `hugo-lithium` with a new site (which we showed i
     # for example, create a new site with the anatole theme
     blogdown::new_site(theme = 'lxndrblz/anatole')
     ```
-
 
 1. Play with the new site for a while and if you do not like it, you can repeat the above steps, otherwise edit the options in the configuration file (`config.yaml` or `config.toml`). If you do not understand certain options, go to the documentation of the theme, which is often the README page of the GitHub repository. Not all options have to be changed.
 

--- a/docs/01-introduction.Rmd
+++ b/docs/01-introduction.Rmd
@@ -167,7 +167,7 @@ ggplot(Orange, aes(x = age,
                    color = Tree)) +
   geom_point() +
   geom_line() +
-  guides(color = FALSE) +
+  guides(color = "none") +
   theme_bw()
 ```
 ````
@@ -548,12 +548,15 @@ blogdown::new_site(theme = 'lxndrblz/anatole')
 
 To save you some time, we list a few themes below that match our taste:
 
-- Simple/minimal themes: [XMin,](https://themes.gohugo.io/hugo-xmin/) [Tanka,](https://themes.gohugo.io/hugo-tanka/)
-[Cupper,](https://themes.gohugo.io/cupper-hugo-theme/)
-[simple-a,](https://themes.gohugo.io/simple-a/) and [ghostwriter.](https://themes.gohugo.io/ghostwriter/)
+- Simple/minimal themes: [XMin,](https://themes.gohugo.io/hugo-xmin/) 
+[Tanka,](https://themes.gohugo.io/hugo-tanka/) 
+[Cupper,](https://themes.gohugo.io/cupper-hugo-theme/) and 
+[ghostwriter.](https://themes.gohugo.io/ghostwriter/)
 
-- Sophisticated themes: [Even,](https://themes.gohugo.io/hugo-theme-even/) [Tranquilpeak,](https://themes.gohugo.io/hugo-tranquilpeak-theme/)
-[Creative portfolio,](https://themes.gohugo.io/hugo-creative-portfolio-theme/) and [Universal.](https://themes.gohugo.io/hugo-universal-theme/)
+- Sophisticated themes: [Even,](https://themes.gohugo.io/hugo-theme-even/) 
+[Tranquilpeak,](https://themes.gohugo.io/hugo-tranquilpeak-theme/) 
+[Creative portfolio,](https://themes.gohugo.io/hugo-creative-portfolio-theme/) and 
+[Universal.](https://themes.gohugo.io/hugo-universal-theme/)
 
 - Multimedia content themes: If you are interested in adding multimedia content to your site (such as audio files of a podcast), the [castanet](https://github.com/mattstratton/castanet) theme provides an excellent framework tailored for this application.  An example of a site using **blogdown** with the castanet theme is the [R-Podcast.](https://www.r-podcast.org)
 

--- a/docs/02-hugo.Rmd
+++ b/docs/02-hugo.Rmd
@@ -216,7 +216,7 @@ blogdown::shortcode('tweet', '852205086956818432')
 
 A Hugo theme\index{Themes} is a collection of template files and optional website assets such as CSS and JavaScript files. In a nutshell, a theme defines what your website looks like after your source content is rendered through the templates.
 
-Hugo has provided a large number of user-contributed themes at https://themes.gohugo.io. Unless you are an experienced web designer, you'd better start from an existing theme here. The quality and complexity of these themes vary a lot, and you should choose one with caution. For example, you may take a look at the number of stars of a theme repository on GitHub, as well as whether the repository is still relatively active. We do not recommend that you use a theme that has not been updated for more than a year.
+Hugo has provided a large number of user-contributed themes at https://themes.gohugo.io. Unless you are an experienced web designer, you'd better start from an existing theme here. The quality and complexity of these themes vary a lot, and you should choose one with caution. For example, you may take a look at the number of stars of a theme repository on GitHub, as well as whether the repository is still relatively active. Themes that have not been updated for a long time (e.g., a couple of years) may or may not still work with a later version of Hugo. You will have to test them carefully.
 
 In this section, we will explain how the default theme in **blogdown** works, which may also give you some ideas about how to get started with other themes.
 


### PR DESCRIPTION
Going through the book for educational purposes.
Since some parts of the book are not fully up to date I suggest the following changes:
 - changed deprecated FALSE value in example
 - removed link to "simple-a", theme not updated for over 2 years now